### PR TITLE
feat: add RSS/Atom feed parser, update to v1.0.0-beta.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,35 +46,37 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Determine npm tag
+        id: npm-tag
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          if [[ "$TAG" == *"-alpha"* ]]; then
+            echo "tag=alpha" >> $GITHUB_OUTPUT
+          elif [[ "$TAG" == *"-beta"* ]]; then
+            echo "tag=beta" >> $GITHUB_OUTPUT
+          elif [[ "$TAG" == *"-rc"* ]]; then
+            echo "tag=next" >> $GITHUB_OUTPUT
+          else
+            echo "tag=latest" >> $GITHUB_OUTPUT
+          fi
+          echo "Publishing with npm tag: $(cat $GITHUB_OUTPUT | grep tag | cut -d= -f2)"
+
       - name: Publish to npm (with provenance)
         id: publish
         continue-on-error: true
-        run: |
-          TAG="${{ github.event.release.tag_name }}"
-          IS_PRERELEASE="${{ github.event.release.prerelease }}"
-
-          if [[ "$IS_PRERELEASE" == "true" || "$TAG" == *-* ]]; then
-            npm publish --provenance --access public --tag alpha
-          else
-            npm publish --provenance --access public
-          fi
+        run: npm publish --provenance --access public --tag ${{ steps.npm-tag.outputs.tag }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish to npm (token fallback)
         if: steps.publish.outcome == 'failure'
         run: |
-          TAG="${{ github.event.release.tag_name }}"
-          IS_PRERELEASE="${{ github.event.release.prerelease }}"
-
           if [[ -z "$NODE_AUTH_TOKEN" ]]; then
             echo "::error::Provenance publishing failed and NPM_TOKEN is not set"
             exit 1
           fi
 
           echo "Provenance publishing failed, falling back to token auth..."
-          if [[ "$IS_PRERELEASE" == "true" || "$TAG" == *-* ]]; then
-            npm publish --access public --tag alpha
-          else
-            npm publish --access public
-          fi
+          npm publish --access public --tag ${{ steps.npm-tag.outputs.tag }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -295,6 +295,11 @@ console.log(result.data.title);   // Feed title
 console.log(result.data.items);   // Array of feed items
 ```
 
+**Supported formats:**
+- `rss2` - RSS 2.0 (most common format)
+- `rss1` - RSS 1.0 (RDF-based, older format)
+- `atom` - Atom 1.0 (modern format with better semantics)
+
 ### Feed Item Structure
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -391,8 +391,12 @@ console.log(item.customFields?.explicit);  // 'no'
 
 ### Security
 
-- **HTTPS-only URLs**: All links are resolved to HTTPS only. Non-HTTPS URLs (http, javascript, data, file) are rejected and returned as empty strings.
+The RSS parser enforces strict URL security:
+
+- **HTTPS-only URLs (RSS parser only)**: The RSS/Atom parser (`RSSParser`) resolves all links to HTTPS only. Non-HTTPS URLs (http, javascript, data, file) are rejected and returned as empty strings. This is specific to feed parsing to prevent malicious links in untrusted feeds.
 - **XML Mode**: Feeds are parsed with Cheerio's `{ xml: true }` mode, which disables HTML entity processing and prevents XSS vectors.
+
+> **Note**: The public URL utilities (`resolveUrl`, `isValidUrl`, etc.) accept both `http:` and `https:` URLs. Protocol-relative URLs (e.g., `//example.com/path`) are resolved against the base URL's protocol by the standard `URL` constructor.
 
 ## URL Utilities
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Modern web scraper with LLM-enhanced extraction, extensible pipeline, and pluggable parsers.
 
-> **Alpha Release**: v1.0.0 is currently in alpha. The API may change before the stable release.
+> **Beta Release**: v1.0.0 is currently in beta. The API is stable but minor changes may occur before the stable release.
 
 ## Features
 
@@ -18,7 +18,7 @@ Modern web scraper with LLM-enhanced extraction, extensible pipeline, and plugga
 ## Installation
 
 ```bash
-npm install scrapex@alpha
+npm install scrapex@beta
 ```
 
 ### Optional Peer Dependencies

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -39,6 +39,7 @@ export default defineConfig({
           label: 'Guides',
           items: [
             { label: 'Basic Scraping', slug: 'guides/basic-scraping' },
+            { label: 'RSS/Atom Parsing', slug: 'guides/rss-parsing' },
             { label: 'LLM Integration', slug: 'guides/llm-integration' },
             { label: 'Custom Extractors', slug: 'guides/custom-extractors' },
             { label: 'Markdown Parsing', slug: 'guides/markdown-parsing' },

--- a/docs/src/content/docs/api/extractors.mdx
+++ b/docs/src/content/docs/api/extractors.mdx
@@ -10,9 +10,7 @@ Extractors are responsible for parsing HTML and extracting structured data.
 ```typescript
 interface Extractor {
   readonly name: string;
-  readonly priority: number;
-
-  canHandle?(context: ExtractionContext): boolean;
+  readonly priority?: number;
   extract(context: ExtractionContext): Promise<Partial<ScrapedData>>;
 }
 ```
@@ -22,17 +20,9 @@ interface Extractor {
 | Property | Type | Description |
 |----------|------|-------------|
 | `name` | `string` | Unique identifier for the extractor |
-| `priority` | `number` | Execution order (higher runs first) |
+| `priority` | `number` | Optional execution order (higher runs first) |
 
 ### Methods
-
-#### canHandle(context)
-
-Optional method to determine if the extractor should run.
-
-- **Parameters:** `context: ExtractionContext`
-- **Returns:** `boolean`
-- **Default:** `true` (runs for all pages)
 
 #### extract(context)
 
@@ -45,9 +35,12 @@ Main extraction method. Returns partial data to merge into the result.
 
 ```typescript
 interface ExtractionContext {
-  $: CheerioAPI;           // Cheerio instance for DOM queries
   url: string;             // Original URL being scraped
-  document: Document;      // Readability parsed document
+  finalUrl: string;        // Final URL after redirects
+  html: string;            // Raw HTML
+  $: CheerioAPI;           // Cheerio instance for DOM queries
+  getDocument(): Document; // Lazy JSDOM document
+  results: Partial<ScrapedData>;
   options: ScrapeOptions;  // Options passed to scrape()
 }
 ```
@@ -72,11 +65,11 @@ import { MetaExtractor } from 'scrapex/extractors';
 
 ### ContentExtractor
 
-**Priority:** 90
+**Priority:** 50
 
 Extracts main content using Readability algorithm:
 
-- Main article content (HTML)
+- Main article content (Markdown)
 - Plain text content
 - Excerpt
 - Byline detection
@@ -102,9 +95,24 @@ Supports multiple `@type` values including Article, NewsArticle, BlogPosting, Pr
 import { JsonLdExtractor } from 'scrapex/extractors';
 ```
 
-### LinksExtractor
+### FaviconExtractor
 
 **Priority:** 70
+
+Extracts favicon URL from multiple sources:
+
+- `<link rel="icon">` and `<link rel="shortcut icon">`
+- Apple touch icons
+- Manifest icons
+- Falls back to `/favicon.ico`
+
+```typescript
+import { FaviconExtractor } from 'scrapex/extractors';
+```
+
+### LinksExtractor
+
+**Priority:** 30
 
 Extracts and categorizes links:
 
@@ -116,14 +124,14 @@ Extracts and categorizes links:
 import { LinksExtractor } from 'scrapex/extractors';
 ```
 
-## defaultExtractors
+## createDefaultExtractors
 
 Array of all built-in extractors in priority order:
 
 ```typescript
-import { defaultExtractors } from 'scrapex';
+import { createDefaultExtractors } from 'scrapex';
 
-// [MetaExtractor, ContentExtractor, JsonLdExtractor, LinksExtractor]
+const extractors = createDefaultExtractors();
 ```
 
 ## Creating Custom Extractors
@@ -135,13 +143,12 @@ class VideoExtractor implements Extractor {
   readonly name = 'video';
   readonly priority = 60;
 
-  canHandle(context: ExtractionContext): boolean {
-    const { $ } = context;
-    return $('video, iframe[src*="youtube"], iframe[src*="vimeo"]').length > 0;
-  }
-
   async extract(context: ExtractionContext): Promise<Partial<ScrapedData>> {
     const { $ } = context;
+
+    if ($('video, iframe[src*="youtube"], iframe[src*="vimeo"]').length === 0) {
+      return {};
+    }
 
     const videos = $('video source, iframe[src*="youtube"], iframe[src*="vimeo"]')
       .map((_, el) => {
@@ -163,10 +170,10 @@ class VideoExtractor implements Extractor {
 ## Using Custom Extractors
 
 ```typescript
-import { scrape, defaultExtractors } from 'scrapex';
+import { scrape, createDefaultExtractors } from 'scrapex';
 
 // Add to defaults
-const extractors = [...defaultExtractors, new VideoExtractor()];
+const extractors = [...createDefaultExtractors(), new VideoExtractor()];
 
 // Or replace entirely
 const extractors = [
@@ -181,8 +188,7 @@ const result = await scrape(url, { extractors });
 
 1. Extractors are sorted by priority (highest first)
 2. For each extractor:
-   - `canHandle()` is called if defined
-   - If `true` or undefined, `extract()` is called
+   - `extract()` is called
    - Returned data is merged into the result
 3. Later extractors can override earlier data
 

--- a/docs/src/content/docs/api/llm-providers.mdx
+++ b/docs/src/content/docs/api/llm-providers.mdx
@@ -10,7 +10,7 @@ LLM providers enable AI-powered content enhancement.
 Creates an OpenAI-compatible provider. Works with OpenAI, Azure OpenAI, Ollama, LM Studio, and other compatible APIs.
 
 ```typescript
-function createOpenAI(options: OpenAIOptions): LLMProvider
+function createOpenAI(options?: OpenAICompatibleConfig): LLMProvider
 ```
 
 ### Options
@@ -18,10 +18,8 @@ function createOpenAI(options: OpenAIOptions): LLMProvider
 | Option | Type | Required | Default | Description |
 |--------|------|----------|---------|-------------|
 | `apiKey` | `string` | No* | `OPENAI_API_KEY` env | API key |
-| `baseURL` | `string` | No | OpenAI API | Custom endpoint |
+| `baseUrl` | `string` | No | OpenAI API | Custom endpoint |
 | `model` | `string` | No | `gpt-4o-mini` | Model to use |
-| `maxTokens` | `number` | No | `4096` | Max response tokens |
-| `temperature` | `number` | No | `0.7` | Response randomness |
 
 *Required unless using environment variable or local endpoint.
 
@@ -37,22 +35,38 @@ const openai = createOpenAI({
 });
 
 // Ollama (local)
-const ollama = createOpenAI({
-  baseURL: 'http://localhost:11434/v1',
+    const ollama = createOpenAI({
+      baseUrl: 'http://localhost:11434/v1',
   model: 'llama3.2',
 });
 
 // LM Studio (local)
-const lmstudio = createOpenAI({
-  baseURL: 'http://localhost:1234/v1',
+    const lmstudio = createOpenAI({
+      baseUrl: 'http://localhost:1234/v1',
   model: 'local-model',
 });
 
 // Azure OpenAI
-const azure = createOpenAI({
-  apiKey: process.env.AZURE_OPENAI_KEY,
-  baseURL: 'https://your-resource.openai.azure.com/openai/deployments/your-deployment',
-});
+    const azure = createOpenAI({
+      apiKey: process.env.AZURE_OPENAI_KEY,
+      baseUrl: 'https://your-resource.openai.azure.com/openai/deployments/your-deployment',
+    });
+```
+
+## createOllama()
+
+Create a local Ollama provider (OpenAI-compatible).
+
+```typescript
+function createOllama(config?: { model: string; port?: number }): LLMProvider
+```
+
+## createLMStudio()
+
+Create a local LM Studio provider (OpenAI-compatible).
+
+```typescript
+function createLMStudio(config?: { model: string; port?: number }): LLMProvider
 ```
 
 ## AnthropicProvider
@@ -66,7 +80,7 @@ class AnthropicProvider implements LLMProvider
 ### Constructor
 
 ```typescript
-new AnthropicProvider(options: AnthropicOptions)
+new AnthropicProvider(options?: AnthropicConfig)
 ```
 
 ### Options
@@ -75,7 +89,7 @@ new AnthropicProvider(options: AnthropicOptions)
 |--------|------|----------|---------|-------------|
 | `apiKey` | `string` | No | `ANTHROPIC_API_KEY` env | API key |
 | `model` | `string` | No | `claude-3-5-haiku-20241022` | Model to use |
-| `maxTokens` | `number` | No | `4096` | Max response tokens |
+| `baseUrl` | `string` | No | Anthropic API | Custom endpoint |
 
 ### Example
 
@@ -95,6 +109,7 @@ Implement this interface for custom providers:
 ```typescript
 interface LLMProvider {
   complete(prompt: string, options?: CompletionOptions): Promise<string>;
+  completeJSON<T>(prompt: string, schema: z.ZodType<T>, options?: CompletionOptions): Promise<T>;
 }
 
 interface CompletionOptions {
@@ -124,34 +139,28 @@ class MyProvider implements LLMProvider {
 }
 ```
 
-## createEnhancer()
+## enhance()
 
-Creates an enhancement pipeline from a provider.
+Run LLM enhancements against scraped data.
 
 ```typescript
-function createEnhancer(provider: LLMProvider): EnhancerBuilder
+function enhance(
+  data: ScrapedData,
+  provider: LLMProvider,
+  types: EnhancementType[]
+): Promise<Partial<ScrapedData>>
 ```
-
-### EnhancerBuilder Methods
-
-| Method | Description |
-|--------|-------------|
-| `.summarize()` | Add summarization |
-| `.extractEntities()` | Add entity extraction |
-| `.classify(categories)` | Add classification |
-| `.extractStructured(schema)` | Add structured extraction |
 
 ### Example
 
 ```typescript
-import { createOpenAI, createEnhancer } from 'scrapex/llm';
+import { scrape } from 'scrapex';
+import { createOpenAI, enhance } from 'scrapex/llm';
 
 const provider = createOpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const data = await scrape('https://example.com');
 
-const enhancer = createEnhancer(provider)
-  .summarize()
-  .extractEntities()
-  .classify(['tech', 'business', 'science']);
+const result = await enhance(data, provider, ['summarize', 'entities']);
 ```
 
 ## ask()
@@ -251,63 +260,16 @@ const products = await extract<Product[]>(data, provider, {
 
 ## Enhancement Types
 
-### Summarization
+Use these values in `enhance` when calling `scrape()`:
 
 ```typescript
-.summarize()
+type EnhancementType = 'summarize' | 'tags' | 'entities' | 'classify';
 ```
 
-Adds a `summary` field to the result with a concise summary of the content.
-
-### Entity Extraction
-
-```typescript
-.extractEntities()
-```
-
-Adds an `entities` field with categorized entities:
-
-```typescript
-{
-  people: string[];
-  organizations: string[];
-  locations: string[];
-  technologies: string[];
-  // ... other categories
-}
-```
-
-### Classification
-
-```typescript
-.classify(categories: string[])
-```
-
-Adds a `categories` field with matching categories from the provided list.
-
-### Structured Extraction
-
-```typescript
-.extractStructured(schema: JSONSchema)
-```
-
-Adds a `structured` field with data matching the provided JSON schema.
-
-## Using Enhancers
-
-```typescript
-import { scrape } from 'scrapex';
-
-const result = await scrape('https://example.com', {
-  enhancer,
-});
-
-// Access enhanced data
-console.log(result.summary);
-console.log(result.entities);
-console.log(result.categories);
-console.log(result.structured);
-```
+- `summarize` → `summary`
+- `tags` → `suggestedTags`
+- `entities` → `entities`
+- `classify` → updates `contentType` when confidence is high
 
 ## See Also
 

--- a/docs/src/content/docs/api/parsers.mdx
+++ b/docs/src/content/docs/api/parsers.mdx
@@ -1,37 +1,160 @@
 ---
 title: Parsers
-description: API reference for Markdown parsers.
+description: API reference for Markdown and RSS/Atom parsers.
 ---
 
-Parsers extract structured data from Markdown content.
+Parsers extract structured data from Markdown and feed content.
 
-## MarkdownParser
+## RSSParser
 
-Parses Markdown content to extract headings and links.
+Parses RSS 2.0, RSS 1.0 (RDF), and Atom 1.0 feeds. Only `https` URLs are emitted; other schemes are dropped.
 
 ```typescript
-class MarkdownParser {
-  parse(markdown: string): MarkdownParseResult;
+class RSSParser {
+  constructor(options?: RSSParserOptions);
+  canParse(content: string): boolean;
+  parse(content: string, url?: string): ParserResult<ParsedFeed, FeedMeta>;
+}
+
+interface RSSParserOptions {
+  customFields?: Record<string, string>;
 }
 ```
 
-### MarkdownParseResult
+### ParsedFeed
 
 ```typescript
-interface MarkdownParseResult {
-  headings: Heading[];
-  links: MarkdownLink[];
+interface ParsedFeed {
+  format: 'rss2' | 'rss1' | 'atom';
+  title: string;
+  description?: string;
+  link: string;
+  next?: string;              // Pagination link (Atom)
+  language?: string;
+  lastBuildDate?: string;     // ISO 8601
+  copyright?: string;
+  items: FeedItem[];
+  customFields?: Record<string, string>;
+}
+```
+
+### FeedItem
+
+```typescript
+interface FeedItem {
+  id: string;
+  title: string;
+  link: string;
+  description?: string;
+  content?: string;
+  author?: string;
+  publishedAt?: string;       // ISO 8601
+  rawPublishedAt?: string;    // Original date string
+  updatedAt?: string;         // Atom only
+  categories: string[];
+  enclosure?: FeedEnclosure;
+  customFields?: Record<string, string>;
 }
 
-interface Heading {
-  level: number;  // 1-6
-  text: string;
+interface FeedEnclosure {
+  url: string;
+  type?: string;              // MIME type
+  length?: number;            // bytes
+}
+```
+
+### FeedMeta
+
+```typescript
+interface FeedMeta {
+  generator?: string;
+  ttl?: number;               // Refresh interval (minutes)
+  image?: {
+    url: string;
+    title?: string;
+    link?: string;
+  };
+  categories?: string[];
+}
+```
+
+### Example
+
+```typescript
+import { RSSParser } from 'scrapex';
+
+const parser = new RSSParser();
+const result = parser.parse(feedXml, 'https://example.com/feed.xml');
+
+console.log(result.data.format);  // 'rss2'
+console.log(result.data.title);   // 'My Blog'
+
+for (const item of result.data.items) {
+  console.log(item.title);        // 'Article Title'
+  console.log(item.publishedAt);  // '2024-09-06T16:45:00.000Z'
+  console.log(item.categories);   // ['Tech', 'News']
+}
+```
+
+### Custom Fields
+
+Extract namespace fields (iTunes, Media RSS):
+
+```typescript
+const parser = new RSSParser({
+  customFields: {
+    duration: 'itunes\\:duration',
+    explicit: 'itunes\\:explicit',
+  },
+});
+
+const result = parser.parse(podcastXml);
+console.log(result.data.items[0].customFields?.duration);
+// '10:00'
+```
+
+---
+
+## MarkdownParser
+
+Parses Markdown content to extract structure, links, and code blocks.
+
+```typescript
+class MarkdownParser {
+  parse(markdown: string): ParserResult<ParsedMarkdown>;
+}
+```
+
+### ParsedMarkdown
+
+```typescript
+interface ParsedMarkdown {
+  title?: string;
+  description?: string;
+  sections: MarkdownSection[];
+  links: MarkdownLink[];
+  codeBlocks: CodeBlock[];
+  frontmatter?: Record<string, unknown>;
+}
+
+interface MarkdownSection {
+  level: number;
+  title: string;
+  content: string;
+  links: MarkdownLink[];
 }
 
 interface MarkdownLink {
   url: string;
   text: string;
-  description: string;
+  title?: string;
+  context?: string;
+}
+
+interface CodeBlock {
+  language?: string;
+  code: string;
+  meta?: string;
 }
 ```
 
@@ -49,104 +172,17 @@ Some text with a [link](https://example.com).
 
 ## Section
 
-- [Item 1](https://one.com) - First item
-- [Item 2](https://two.com) - Second item
+- [Item 1](https://one.com)
+- [Item 2](https://two.com)
 `);
 
-console.log(result.headings);
-// [
-//   { level: 1, text: 'Title' },
-//   { level: 2, text: 'Section' },
-// ]
-
-console.log(result.links);
-// [
-//   { url: 'https://example.com', text: 'link', description: '' },
-//   { url: 'https://one.com', text: 'Item 1', description: 'First item' },
-//   { url: 'https://two.com', text: 'Item 2', description: 'Second item' },
-// ]
-```
-
-### Link Description Patterns
-
-The parser extracts descriptions from these patterns:
-
-```markdown
-- [Link](url) - Description with dash
-- [Link](url): Description with colon
-- [Link](url) — Description with em dash
-```
-
-## GithubMarkdownParser
-
-Extended parser for GitHub-flavored Markdown.
-
-```typescript
-class GithubMarkdownParser extends MarkdownParser {
-  parseGithubReadme(markdown: string): GithubReadmeResult;
-}
-```
-
-### GithubReadmeResult
-
-```typescript
-interface GithubReadmeResult extends MarkdownParseResult {
-  badges: Badge[];
-  tableOfContents: TOCEntry[];
-}
-
-interface Badge {
-  alt: string;
-  url: string;
-  link?: string;
-}
-
-interface TOCEntry {
-  text: string;
-  anchor: string;
-  level: number;
-}
-```
-
-### Example
-
-```typescript
-import { GithubMarkdownParser } from 'scrapex/parsers';
-
-const parser = new GithubMarkdownParser();
-
-const result = parser.parseGithubReadme(`
-# My Project
-
-[![npm](https://img.shields.io/npm/v/my-project)](https://npmjs.com/package/my-project)
-[![CI](https://github.com/user/repo/actions/workflows/ci.yml/badge.svg)](https://github.com/user/repo/actions)
-
-## Contents
-
-- [Installation](#installation)
-- [Usage](#usage)
-
-## Installation
-
-\`\`\`bash
-npm install my-project
-\`\`\`
-`);
-
-console.log(result.badges);
-// [
-//   { alt: 'npm', url: 'https://img.shields.io/npm/v/my-project', link: 'https://npmjs.com/package/my-project' },
-//   { alt: 'CI', url: '...badge.svg', link: '...actions' },
-// ]
-
-console.log(result.tableOfContents);
-// [
-//   { text: 'Installation', anchor: 'installation', level: 2 },
-//   { text: 'Usage', anchor: 'usage', level: 2 },
-// ]
+console.log(result.data.sections[0].title);
+console.log(result.data.links.length);
+console.log(result.data.codeBlocks.length);
 ```
 
 ## See Also
 
-- [Markdown Parsing Guide](/guides/markdown-parsing) - Detailed usage guide
+- [RSS/Atom Parsing Guide](/guides/rss-parsing) - RSS feed parsing guide
+- [Markdown Parsing Guide](/guides/markdown-parsing) - Markdown parsing guide
 - [Types Reference](/api/types) - Full type definitions

--- a/docs/src/content/docs/api/scrape-html.mdx
+++ b/docs/src/content/docs/api/scrape-html.mdx
@@ -40,9 +40,12 @@ Same options as `scrape()`, except network-related options are ignored.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `extractors` | `Extractor[]` | `defaultExtractors` | Custom extractor pipeline |
-| `enhancer` | `Enhancer` | `undefined` | LLM enhancement pipeline |
-| `maxContentLength` | `number` | `undefined` | Max content length to process |
+| `extractors` | `Extractor[]` | `createDefaultExtractors()` | Custom extractor pipeline |
+| `replaceDefaultExtractors` | `boolean` | `false` | Replace default extractor set |
+| `maxContentLength` | `number` | `50000` | Max content length to process |
+| `llm` | `LLMProvider` | `undefined` | LLM provider for enhancements |
+| `enhance` | `EnhancementType[]` | `undefined` | LLM enhancement types |
+| `extract` | `ExtractionSchema` | `undefined` | LLM structured extraction schema |
 
 ## Returns
 
@@ -103,7 +106,7 @@ const result = await scrapeHtml(html, response.url);
 ### With Custom Extractors
 
 ```typescript
-import { scrapeHtml, defaultExtractors, type Extractor } from 'scrapex';
+import { scrapeHtml, createDefaultExtractors, type Extractor } from 'scrapex';
 
 class PriceExtractor implements Extractor {
   readonly name = 'price';
@@ -117,7 +120,7 @@ class PriceExtractor implements Extractor {
 }
 
 const result = await scrapeHtml(html, url, {
-  extractors: [...defaultExtractors, new PriceExtractor()],
+  extractors: [...createDefaultExtractors(), new PriceExtractor()],
 });
 ```
 
@@ -127,7 +130,7 @@ const result = await scrapeHtml(html, url, {
 
 ```typescript
 import { describe, it, expect } from 'vitest';
-import { scrapeHtml, defaultExtractors } from 'scrapex';
+import { scrapeHtml, createDefaultExtractors } from 'scrapex';
 import { MyExtractor } from './my-extractor';
 
 describe('MyExtractor', () => {
@@ -140,9 +143,9 @@ describe('MyExtractor', () => {
       </html>
     `;
 
-    const result = await scrapeHtml(html, 'https://example.com', {
-      extractors: [...defaultExtractors, new MyExtractor()],
-    });
+  const result = await scrapeHtml(html, 'https://example.com', {
+    extractors: [...createDefaultExtractors(), new MyExtractor()],
+  });
 
     expect(result.custom?.myData).toBe('Test Value');
   });

--- a/docs/src/content/docs/api/scrape.mdx
+++ b/docs/src/content/docs/api/scrape.mdx
@@ -27,13 +27,17 @@ The URL to scrape. Must be a valid HTTP or HTTPS URL.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `timeout` | `number` | `30000` | Request timeout in milliseconds |
-| `headers` | `Record<string, string>` | `{}` | Custom HTTP headers |
+| `timeout` | `number` | `10000` | Request timeout in milliseconds |
 | `userAgent` | `string` | Default UA | Custom User-Agent string |
+| `extractContent` | `boolean` | `true` | Extract full content with Readability |
+| `maxContentLength` | `number` | `50000` | Max content length to process |
+| `fetcher` | `Fetcher` | `defaultFetcher` | Custom fetcher (Puppeteer/Playwright) |
+| `extractors` | `Extractor[]` | `createDefaultExtractors()` | Custom extractor pipeline |
+| `replaceDefaultExtractors` | `boolean` | `false` | Replace default extractor set |
 | `respectRobots` | `boolean` | `false` | Respect robots.txt rules |
-| `maxContentLength` | `number` | `undefined` | Max content length to process |
-| `extractors` | `Extractor[]` | `defaultExtractors` | Custom extractor pipeline |
-| `enhancer` | `Enhancer` | `undefined` | LLM enhancement pipeline |
+| `llm` | `LLMProvider` | `undefined` | LLM provider for enhancements |
+| `enhance` | `EnhancementType[]` | `undefined` | LLM enhancement types |
+| `extract` | `ExtractionSchema` | `undefined` | LLM structured extraction schema |
 
 ## Returns
 
@@ -42,26 +46,35 @@ Returns a `Promise<ScrapedData>` with the extracted data.
 ```typescript
 interface ScrapedData {
   url: string;
+  canonicalUrl: string;
+  domain: string;
   title: string;
-  description?: string;
-  author?: string;
-  publishedDate?: string;
+  description: string;
+  image?: string;
+  favicon?: string;
   content: string;
   textContent: string;
-  excerpt?: string;
+  excerpt: string;
+  wordCount: number;
+  author?: string;
+  publishedAt?: string;
+  modifiedAt?: string;
   siteName?: string;
-  favicon?: string;
-  image?: string;
-  links: LinkInfo[];
-  contentType?: string;
   language?: string;
+  contentType: ContentType;
+  keywords: string[];
+  jsonLd?: Record<string, unknown>[];
+  links?: ExtractedLink[];
   custom?: Record<string, unknown>;
+  scrapedAt: string;
+  scrapeTimeMs: number;
+  error?: string;
 
-  // LLM-enhanced fields (when enhancer is provided)
+  // LLM-enhanced fields (when llm + enhance/extract is provided)
   summary?: string;
-  entities?: Record<string, string[]>;
-  categories?: string[];
-  structured?: unknown;
+  suggestedTags?: string[];
+  entities?: ExtractedEntities;
+  extracted?: Record<string, unknown>;
 }
 ```
 
@@ -84,9 +97,7 @@ console.log(result.links);
 ```typescript
 const result = await scrape('https://example.com', {
   timeout: 10000,
-  headers: {
-    'Accept-Language': 'en-US',
-  },
+  userAgent: 'MyBot/1.0',
   respectRobots: true,
 });
 ```
@@ -95,14 +106,14 @@ const result = await scrape('https://example.com', {
 
 ```typescript
 import { scrape } from 'scrapex';
-import { createOpenAI, createEnhancer } from 'scrapex/llm';
+import { createOpenAI } from 'scrapex/llm';
 
 const provider = createOpenAI({ apiKey: process.env.OPENAI_API_KEY });
-const enhancer = createEnhancer(provider)
-  .summarize()
-  .extractEntities();
 
-const result = await scrape('https://example.com', { enhancer });
+const result = await scrape('https://example.com', {
+  llm: provider,
+  enhance: ['summarize', 'entities'],
+});
 
 console.log(result.summary);
 console.log(result.entities);
@@ -111,11 +122,11 @@ console.log(result.entities);
 ### With Custom Extractors
 
 ```typescript
-import { scrape, defaultExtractors } from 'scrapex';
+import { scrape, createDefaultExtractors } from 'scrapex';
 import { MyCustomExtractor } from './extractors';
 
 const result = await scrape('https://example.com', {
-  extractors: [...defaultExtractors, new MyCustomExtractor()],
+  extractors: [...createDefaultExtractors(), new MyCustomExtractor()],
 });
 
 console.log(result.custom?.myData);
@@ -130,9 +141,10 @@ try {
   const result = await scrape('https://example.com');
 } catch (error) {
   if (error instanceof ScrapeError) {
-    console.log(error.code);    // 'FETCH_ERROR', 'TIMEOUT', etc.
-    console.log(error.url);     // The URL that failed
-    console.log(error.message); // Error description
+    console.log(error.code);       // 'FETCH_FAILED', 'TIMEOUT', etc.
+    console.log(error.message);    // Error description
+    console.log(error.statusCode); // HTTP status if applicable
+    console.log(error.isRetryable()); // true for transient errors
   }
 }
 ```

--- a/docs/src/content/docs/api/types.mdx
+++ b/docs/src/content/docs/api/types.mdx
@@ -13,38 +13,53 @@ The main result type returned by `scrape()` and `scrapeHtml()`.
 
 ```typescript
 interface ScrapedData {
-  // Basic metadata
+  // Identity
   url: string;
+  canonicalUrl: string;
+  domain: string;
+
+  // Basic metadata
   title: string;
-  description?: string;
-  author?: string;
-  publishedDate?: string;
+  description: string;
+  image?: string;
+  favicon?: string;
 
   // Content
-  content: string;         // HTML content
-  textContent: string;     // Plain text content
-  excerpt?: string;
+  content: string;      // Markdown content
+  textContent: string;  // Plain text content
+  excerpt: string;
+  wordCount: number;
 
-  // Site information
+  // Context
+  author?: string;
+  publishedAt?: string;
+  modifiedAt?: string;
   siteName?: string;
-  favicon?: string;
-  image?: string;
   language?: string;
 
-  // Links
-  links: LinkInfo[];
-
   // Classification
-  contentType?: string;
+  contentType: ContentType;
+  keywords: string[];
+
+  // Structured data
+  jsonLd?: Record<string, unknown>[];
+
+  // Links
+  links?: ExtractedLink[];
+
+  // LLM-enhanced fields
+  summary?: string;
+  suggestedTags?: string[];
+  entities?: ExtractedEntities;
+  extracted?: Record<string, unknown>;
 
   // Custom extractor data
   custom?: Record<string, unknown>;
 
-  // LLM-enhanced fields
-  summary?: string;
-  entities?: Record<string, string[]>;
-  categories?: string[];
-  structured?: unknown;
+  // Meta
+  scrapedAt: string;
+  scrapeTimeMs: number;
+  error?: string;
 }
 ```
 
@@ -56,28 +71,63 @@ Options for the `scrape()` and `scrapeHtml()` functions.
 interface ScrapeOptions {
   // HTTP options (scrape() only)
   timeout?: number;
-  headers?: Record<string, string>;
   userAgent?: string;
 
   // Behavior
-  respectRobots?: boolean;
+  extractContent?: boolean;
   maxContentLength?: number;
+  respectRobots?: boolean;
 
   // Pipeline customization
+  fetcher?: Fetcher;
   extractors?: Extractor[];
-  enhancer?: Enhancer;
+  replaceDefaultExtractors?: boolean;
+
+  // LLM integration
+  llm?: LLMProvider;
+  enhance?: EnhancementType[];
+  extract?: ExtractionSchema;
 }
 ```
 
-### LinkInfo
+### ContentType
+
+Content type classification for scraped URLs.
+
+```typescript
+type ContentType =
+  | 'article'
+  | 'repo'
+  | 'docs'
+  | 'package'
+  | 'video'
+  | 'tool'
+  | 'product'
+  | 'unknown';
+```
+
+### ExtractedEntities
+
+Entities extracted by LLM enhancement.
+
+```typescript
+interface ExtractedEntities {
+  people: string[];
+  organizations: string[];
+  technologies: string[];
+  locations: string[];
+  concepts: string[];
+}
+```
+
+### ExtractedLink
 
 Information about an extracted link.
 
 ```typescript
-interface LinkInfo {
+interface ExtractedLink {
   url: string;
   text: string;
-  rel?: string;
   isExternal: boolean;
 }
 ```
@@ -91,9 +141,8 @@ Interface for content extractors.
 ```typescript
 interface Extractor {
   readonly name: string;
-  readonly priority: number;
+  readonly priority?: number;
 
-  canHandle?(context: ExtractionContext): boolean;
   extract(context: ExtractionContext): Promise<Partial<ScrapedData>>;
 }
 ```
@@ -104,28 +153,46 @@ Context passed to extractors.
 
 ```typescript
 interface ExtractionContext {
-  $: CheerioAPI;
   url: string;
-  document: Document;
+  finalUrl: string;
+  html: string;
+  $: CheerioAPI;
+  getDocument(): Document;
+  results: Partial<ScrapedData>;
   options: ScrapeOptions;
 }
 ```
 
-### Document
+## Fetcher Types
 
-Readability parsed document.
+### Fetcher
 
 ```typescript
-interface Document {
-  title: string;
-  content: string;
-  textContent: string;
-  length: number;
-  excerpt: string;
-  byline: string | null;
-  dir: string | null;
-  siteName: string | null;
-  lang: string | null;
+interface Fetcher {
+  readonly name: string;
+  fetch(url: string, options: FetchOptions): Promise<FetchResult>;
+}
+```
+
+### FetchOptions
+
+```typescript
+interface FetchOptions {
+  timeout?: number;
+  userAgent?: string;
+  headers?: Record<string, string>;
+}
+```
+
+### FetchResult
+
+```typescript
+interface FetchResult {
+  html: string;
+  finalUrl: string;
+  statusCode: number;
+  contentType: string;
+  headers?: Record<string, string>;
 }
 ```
 
@@ -137,7 +204,9 @@ Interface for LLM providers.
 
 ```typescript
 interface LLMProvider {
+  readonly name: string;
   complete(prompt: string, options?: CompletionOptions): Promise<string>;
+  completeJSON<T>(prompt: string, schema: unknown): Promise<T>;
 }
 ```
 
@@ -153,52 +222,27 @@ interface CompletionOptions {
 }
 ```
 
-### OpenAIOptions
+### OpenAICompatibleConfig
 
-Options for `createOpenAI()`.
+Options for `createOpenAI()`, `createOllama()`, and `createLMStudio()`.
 
 ```typescript
-interface OpenAIOptions {
+interface OpenAICompatibleConfig {
   apiKey?: string;
-  baseURL?: string;
   model?: string;
-  maxTokens?: number;
-  temperature?: number;
+  baseUrl?: string;
 }
 ```
 
-### AnthropicOptions
+### AnthropicConfig
 
 Options for `AnthropicProvider`.
 
 ```typescript
-interface AnthropicOptions {
+interface AnthropicConfig {
   apiKey?: string;
   model?: string;
-  maxTokens?: number;
-}
-```
-
-### Enhancer
-
-LLM enhancement pipeline.
-
-```typescript
-interface Enhancer {
-  enhance(data: ScrapedData): Promise<Partial<ScrapedData>>;
-}
-```
-
-### EnhancerBuilder
-
-Builder for creating enhancers.
-
-```typescript
-interface EnhancerBuilder extends Enhancer {
-  summarize(): EnhancerBuilder;
-  extractEntities(): EnhancerBuilder;
-  classify(categories: string[]): EnhancerBuilder;
-  extractStructured(schema: JSONSchema): EnhancerBuilder;
+  baseUrl?: string;
 }
 ```
 
@@ -231,27 +275,41 @@ type ExtractionSchemaType =
 type ExtractionSchema = Record<string, ExtractionSchemaType>;
 ```
 
+### EnhancementType
+
+Supported enhancement types for `scrape()`:
+
+```typescript
+type EnhancementType = 'summarize' | 'tags' | 'entities' | 'classify';
+```
+
 ## Parser Types
 
-### MarkdownParseResult
+### ParsedMarkdown
 
 Result from `MarkdownParser.parse()`.
 
 ```typescript
-interface MarkdownParseResult {
-  headings: Heading[];
+interface ParsedMarkdown {
+  title?: string;
+  description?: string;
+  sections: MarkdownSection[];
   links: MarkdownLink[];
+  codeBlocks: CodeBlock[];
+  frontmatter?: Record<string, unknown>;
 }
 ```
 
-### Heading
+### MarkdownSection
 
-A Markdown heading.
+A Markdown section (heading + content).
 
 ```typescript
-interface Heading {
+interface MarkdownSection {
   level: number;
-  text: string;
+  title: string;
+  content: string;
+  links: MarkdownLink[];
 }
 ```
 
@@ -263,7 +321,20 @@ A link extracted from Markdown.
 interface MarkdownLink {
   url: string;
   text: string;
-  description: string;
+  title?: string;
+  context?: string;
+}
+```
+
+### CodeBlock
+
+A code block extracted from Markdown.
+
+```typescript
+interface CodeBlock {
+  language?: string;
+  code: string;
+  meta?: string;
 }
 ```
 
@@ -271,29 +342,34 @@ interface MarkdownLink {
 
 ### ScrapeError
 
-Custom error class.
+Custom error class for scraping failures.
 
 ```typescript
 class ScrapeError extends Error {
-  readonly code: ErrorCode;
-  readonly url?: string;
+  readonly code: ScrapeErrorCode;
   readonly statusCode?: number;
+
+  static from(error: unknown, code?: ScrapeErrorCode): ScrapeError;
+  isRetryable(): boolean;
+  toJSON(): Record<string, unknown>;
 }
 ```
 
-### ErrorCode
+### ScrapeErrorCode
 
 Possible error codes.
 
 ```typescript
-type ErrorCode =
-  | 'FETCH_ERROR'
+type ScrapeErrorCode =
+  | 'FETCH_FAILED'
   | 'TIMEOUT'
-  | 'HTTP_ERROR'
-  | 'PARSE_ERROR'
-  | 'ROBOTS_BLOCKED'
   | 'INVALID_URL'
-  | 'CONTENT_TOO_LARGE';
+  | 'BLOCKED'
+  | 'NOT_FOUND'
+  | 'ROBOTS_BLOCKED'
+  | 'PARSE_ERROR'
+  | 'LLM_ERROR'
+  | 'VALIDATION_ERROR';
 ```
 
 ## Importing Types
@@ -303,7 +379,9 @@ type ErrorCode =
 import type {
   ScrapedData,
   ScrapeOptions,
-  LinkInfo,
+  ExtractedLink,
+  EnhancementType,
+  ExtractionSchema,
 } from 'scrapex';
 
 // Extractor types
@@ -316,14 +394,15 @@ import type {
 import type {
   LLMProvider,
   CompletionOptions,
-  Enhancer,
-  EnhancerBuilder,
   AskOptions,
 } from 'scrapex/llm';
 
 // Parser types
 import type {
-  MarkdownParseResult,
+  ParsedMarkdown,
+  MarkdownSection,
+  MarkdownLink,
+  CodeBlock,
 } from 'scrapex/parsers';
 ```
 

--- a/docs/src/content/docs/api/utilities.mdx
+++ b/docs/src/content/docs/api/utilities.mdx
@@ -244,7 +244,7 @@ const text = feedToText(feed, { maxItems: 5 });
 
 ### paginateFeed()
 
-Iterate through paginated feeds (RFC 5005).
+Iterate through paginated Atom feeds using [RFC 5005](https://tools.ietf.org/html/rfc5005) (Feed Paging and Archiving). This follows `rel="next"` links to fetch subsequent pages.
 
 ```typescript
 function paginateFeed(

--- a/docs/src/content/docs/api/utilities.mdx
+++ b/docs/src/content/docs/api/utilities.mdx
@@ -1,6 +1,6 @@
 ---
 title: Utilities
-description: API reference for URL and text utility functions.
+description: API reference for URL, text, and feed utility functions.
 ---
 
 scrapex provides utility functions for common operations.
@@ -31,7 +31,7 @@ isValidUrl('');                        // false
 Extract the domain from a URL.
 
 ```typescript
-function extractDomain(url: string): string | null
+function extractDomain(url: string): string
 ```
 
 #### Example
@@ -42,7 +42,7 @@ import { extractDomain } from 'scrapex';
 extractDomain('https://www.example.com/page');     // 'example.com'
 extractDomain('https://blog.example.com/post');    // 'blog.example.com'
 extractDomain('https://example.com:8080/api');     // 'example.com'
-extractDomain('invalid');                          // null
+extractDomain('invalid');                          // ''
 ```
 
 ### normalizeUrl()
@@ -54,10 +54,8 @@ function normalizeUrl(url: string): string
 ```
 
 Normalization includes:
-- Lowercasing the hostname
-- Removing default ports (80, 443)
-- Removing trailing slashes
-- Sorting query parameters
+- Removing common tracking parameters
+- Removing trailing slashes (except root)
 
 #### Example
 
@@ -65,13 +63,13 @@ Normalization includes:
 import { normalizeUrl } from 'scrapex';
 
 normalizeUrl('HTTPS://Example.COM/');
-// 'https://example.com'
+// 'HTTPS://Example.COM/'
 
 normalizeUrl('https://example.com:443/page');
-// 'https://example.com/page'
+// 'https://example.com:443/page'
 
-normalizeUrl('https://example.com?b=2&a=1');
-// 'https://example.com?a=1&b=2'
+normalizeUrl('https://example.com?b=2&a=1&utm_source=site');
+// 'https://example.com?b=2&a=1'
 ```
 
 ### resolveUrl()
@@ -79,7 +77,7 @@ normalizeUrl('https://example.com?b=2&a=1');
 Resolve a relative URL against a base URL.
 
 ```typescript
-function resolveUrl(base: string, relative: string): string
+function resolveUrl(url: string | undefined | null, baseUrl: string): string | undefined
 ```
 
 #### Example
@@ -87,13 +85,13 @@ function resolveUrl(base: string, relative: string): string
 ```typescript
 import { resolveUrl } from 'scrapex';
 
-resolveUrl('https://example.com/page/', '../other');
+resolveUrl('../other', 'https://example.com/page/');
 // 'https://example.com/other'
 
-resolveUrl('https://example.com/blog/post', '/about');
+resolveUrl('/about', 'https://example.com/blog/post');
 // 'https://example.com/about'
 
-resolveUrl('https://example.com', 'https://other.com');
+resolveUrl('https://other.com', 'https://example.com');
 // 'https://other.com'
 ```
 
@@ -118,6 +116,156 @@ isExternalUrl('https://example.com/page', 'https://example.com');
 
 isExternalUrl('/page', 'https://example.com');
 // false
+```
+
+## Feed Utilities
+
+### fetchFeed()
+
+Fetch and parse an RSS/Atom feed.
+
+```typescript
+function fetchFeed(
+  url: string,
+  options?: {
+    fetcher?: Fetcher;
+    timeout?: number;
+    userAgent?: string;
+    parserOptions?: RSSParserOptions;
+  }
+): Promise<ParserResult<ParsedFeed, FeedMeta>>
+```
+
+#### Example
+
+```typescript
+import { fetchFeed } from 'scrapex';
+
+const result = await fetchFeed('https://example.com/feed.xml');
+
+for (const item of result.data.items) {
+  console.log(item.title, item.publishedAt);
+}
+```
+
+### discoverFeeds()
+
+Find RSS/Atom feed URLs in HTML.
+
+```typescript
+function discoverFeeds(html: string, baseUrl: string): string[]
+```
+
+#### Example
+
+```typescript
+import { discoverFeeds } from 'scrapex';
+
+const feedUrls = discoverFeeds(html, 'https://example.com');
+// ['https://example.com/feed.xml', 'https://example.com/atom.xml']
+```
+
+### filterByDate()
+
+Filter feed items by date range.
+
+```typescript
+function filterByDate(
+  items: FeedItem[],
+  options: {
+    after?: Date;
+    before?: Date;
+    includeUndated?: boolean;
+  }
+): FeedItem[]
+```
+
+#### Example
+
+```typescript
+import { filterByDate } from 'scrapex';
+
+const recentItems = filterByDate(items, {
+  after: new Date('2024-01-01'),
+  includeUndated: false,
+});
+```
+
+### feedToMarkdown()
+
+Convert feed to Markdown for LLM consumption.
+
+```typescript
+function feedToMarkdown(
+  feed: ParsedFeed,
+  options?: {
+    includeContent?: boolean;
+    maxItems?: number;
+  }
+): string
+```
+
+#### Example
+
+```typescript
+import { feedToMarkdown } from 'scrapex';
+
+const markdown = feedToMarkdown(feed, { maxItems: 10 });
+// # Feed Title
+//
+// ## Article 1
+// *2024-09-06*
+//
+// Article description...
+// [Read more](https://example.com/article)
+```
+
+### feedToText()
+
+Convert feed to plain text.
+
+```typescript
+function feedToText(
+  feed: ParsedFeed,
+  options?: {
+    maxItems?: number;
+    separator?: string;
+  }
+): string
+```
+
+#### Example
+
+```typescript
+import { feedToText } from 'scrapex';
+
+const text = feedToText(feed, { maxItems: 5 });
+```
+
+### paginateFeed()
+
+Iterate through paginated feeds (RFC 5005).
+
+```typescript
+function paginateFeed(
+  url: string,
+  options?: {
+    fetcher?: Fetcher;
+    timeout?: number;
+    userAgent?: string;
+    maxPages?: number;
+  }
+): AsyncGenerator<ParsedFeed>
+```
+
+#### Example
+
+```typescript
+import { paginateFeed } from 'scrapex';
+
+for await (const page of paginateFeed(url, { maxPages: 5 })) {
+  console.log(`Page with ${page.items.length} items`);
+}
 ```
 
 ## Text Utilities
@@ -239,5 +387,6 @@ function createScrapeError(
 
 ## See Also
 
+- [RSS/Atom Parsing Guide](/guides/rss-parsing) - Feed parsing guide
 - [Error Handling Guide](/guides/error-handling) - Error handling patterns
 - [Types Reference](/api/types) - Full type definitions

--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -72,7 +72,7 @@ scrapex provides multiple entry points:
 // Main entry - scraping functions and utilities
 import { scrape, scrapeHtml } from 'scrapex';
 
-// LLM providers and enhancers
+// LLM providers and helpers
 import { createOpenAI, AnthropicProvider } from 'scrapex/llm';
 
 // Markdown parsers

--- a/docs/src/content/docs/guides/custom-extractors.mdx
+++ b/docs/src/content/docs/guides/custom-extractors.mdx
@@ -16,9 +16,7 @@ import type { Extractor, ExtractionContext, ScrapedData } from 'scrapex';
 
 interface Extractor {
   readonly name: string;      // Unique identifier
-  readonly priority: number;  // Execution order (higher = earlier)
-
-  canHandle?(context: ExtractionContext): boolean;
+  readonly priority?: number; // Execution order (higher = earlier)
   extract(context: ExtractionContext): Promise<Partial<ScrapedData>>;
 }
 ```
@@ -29,9 +27,12 @@ The `ExtractionContext` provides access to:
 
 ```typescript
 interface ExtractionContext {
-  $: CheerioAPI;           // Cheerio instance for DOM queries
   url: string;             // Original URL
-  document: Document;      // Readability document
+  finalUrl: string;        // Final URL after redirects
+  html: string;            // Raw HTML
+  $: CheerioAPI;           // Cheerio instance for DOM queries
+  getDocument(): Document; // Lazy JSDOM document
+  results: Partial<ScrapedData>;
   options: ScrapeOptions;  // Scraping options
 }
 ```
@@ -49,14 +50,13 @@ interface ExtractionContext {
      readonly name = 'recipe';
      readonly priority = 60;
 
-     canHandle(context: ExtractionContext): boolean {
-       const { $ } = context;
-       // Only handle pages with recipe schema
-       return $('script[type="application/ld+json"]').text().includes('"Recipe"');
-     }
-
      async extract(context: ExtractionContext): Promise<Partial<ScrapedData>> {
        const { $ } = context;
+
+       // Only handle pages with recipe schema
+       if (!$('script[type="application/ld+json"]').text().includes('"Recipe"')) {
+         return {};
+       }
 
        // Extract recipe-specific data
        const ingredients = $('.ingredients li')
@@ -87,9 +87,9 @@ interface ExtractionContext {
 2. **Register the extractor**
 
    ```typescript
-   import { scrapeHtml, defaultExtractors } from 'scrapex';
+   import { scrapeHtml, createDefaultExtractors } from 'scrapex';
 
-   const extractors = [...defaultExtractors, new RecipeExtractor()];
+   const extractors = [...createDefaultExtractors(), new RecipeExtractor()];
 
    const result = await scrapeHtml(html, url, { extractors });
    ```
@@ -113,31 +113,32 @@ Extractors run in priority order (highest first). Built-in priorities:
 | Priority | Extractor | Purpose |
 |----------|-----------|---------|
 | 100 | MetaExtractor | Title, description, author |
-| 90 | ContentExtractor | Main content, Readability |
 | 80 | JsonLdExtractor | Structured data |
-| 70 | LinksExtractor | Link extraction |
+| 70 | FaviconExtractor | Favicon discovery |
+| 50 | ContentExtractor | Main content, Readability |
+| 30 | LinksExtractor | Link extraction |
 
 <Aside type="tip">
-  Use priority 50-69 for custom extractors that should run after core extraction but before finalization.
+  Use priority 40-60 for custom extractors that should run alongside core content extraction.
 </Aside>
 
 ## Conditional Extraction
 
-Use `canHandle()` to skip extraction for irrelevant pages:
+Check conditions inside `extract()` and return `{}` when not applicable:
 
 ```typescript
 class GitHubRepoExtractor implements Extractor {
   readonly name = 'github-repo';
   readonly priority = 55;
 
-  canHandle(context: ExtractionContext): boolean {
-    return context.url.includes('github.com') &&
-           !context.url.includes('/issues') &&
-           !context.url.includes('/pull');
-  }
-
   async extract(context: ExtractionContext): Promise<Partial<ScrapedData>> {
     const { $ } = context;
+
+    if (!context.url.includes('github.com') ||
+        context.url.includes('/issues') ||
+        context.url.includes('/pull')) {
+      return {};
+    }
 
     return {
       custom: {
@@ -200,20 +201,21 @@ if (product) {
 ## Full Example
 
 ```typescript
-import { scrape, defaultExtractors, type Extractor, type ExtractionContext, type ScrapedData } from 'scrapex';
+import { scrape, createDefaultExtractors, type Extractor, type ExtractionContext, type ScrapedData } from 'scrapex';
 
 class EcommerceExtractor implements Extractor {
   readonly name = 'ecommerce';
   readonly priority = 55;
 
-  canHandle(context: ExtractionContext): boolean {
-    const { $ } = context;
-    return $('[itemtype*="Product"]').length > 0 ||
-           $('.product-price, .price').length > 0;
-  }
-
   async extract(context: ExtractionContext): Promise<Partial<ScrapedData>> {
     const { $ } = context;
+
+    if (
+      $('[itemtype*="Product"]').length === 0 &&
+      $('.product-price, .price').length === 0
+    ) {
+      return {};
+    }
 
     const priceText = $('[itemprop="price"], .product-price, .price')
       .first()
@@ -245,7 +247,7 @@ class EcommerceExtractor implements Extractor {
 }
 
 // Usage
-const extractors = [...defaultExtractors, new EcommerceExtractor()];
+const extractors = [...createDefaultExtractors(), new EcommerceExtractor()];
 const result = await scrape('https://shop.example.com/product', { extractors });
 
 console.log(result.contentType); // 'product'

--- a/docs/src/content/docs/guides/error-handling.mdx
+++ b/docs/src/content/docs/guides/error-handling.mdx
@@ -20,8 +20,8 @@ try {
   if (error instanceof ScrapeError) {
     console.log('Code:', error.code);
     console.log('Message:', error.message);
-    console.log('URL:', error.url);
     console.log('Status:', error.statusCode);
+    console.log('Retryable:', error.isRetryable());
   }
 }
 ```
@@ -30,13 +30,15 @@ try {
 
 | Code | Description | Common Causes |
 |------|-------------|---------------|
-| `FETCH_ERROR` | Failed to fetch URL | Network issues, DNS failure |
+| `FETCH_FAILED` | Failed to fetch URL | Network issues, DNS failure |
 | `TIMEOUT` | Request timed out | Slow server, network issues |
-| `HTTP_ERROR` | Non-2xx HTTP response | 404, 500, rate limiting |
+| `BLOCKED` | Access denied | 403 Forbidden, WAF blocking |
+| `NOT_FOUND` | Page not found | 404 response |
 | `PARSE_ERROR` | Failed to parse HTML | Malformed HTML |
 | `ROBOTS_BLOCKED` | Blocked by robots.txt | `respectRobots: true` and disallowed |
 | `INVALID_URL` | Invalid URL provided | Malformed URL string |
-| `CONTENT_TOO_LARGE` | Response too large | Exceeds size limits |
+| `LLM_ERROR` | LLM provider failed | API error, rate limit, invalid key |
+| `VALIDATION_ERROR` | Validation failed | Schema mismatch, invalid response |
 
 ## Handling Specific Errors
 
@@ -56,17 +58,17 @@ async function safeScrape(url: string) {
         console.log(`Timeout scraping ${url}, retrying...`);
         return await scrape(url, { timeout: 30000 });
 
-      case 'HTTP_ERROR':
+      case 'BLOCKED':
         if (error.statusCode === 429) {
           console.log('Rate limited, waiting...');
           await sleep(5000);
           return await scrape(url);
         }
-        if (error.statusCode === 404) {
-          console.log('Page not found');
-          return null;
-        }
         throw error;
+
+      case 'NOT_FOUND':
+        console.log('Page not found');
+        return null;
 
       case 'ROBOTS_BLOCKED':
         console.log('Blocked by robots.txt, skipping');
@@ -95,8 +97,9 @@ async function scrapeWithRetry(
     } catch (error) {
       if (!(error instanceof ScrapeError)) throw error;
 
-      const isRetryable = ['FETCH_ERROR', 'TIMEOUT'].includes(error.code) ||
-                          (error.code === 'HTTP_ERROR' && error.statusCode === 429);
+      // Use built-in isRetryable() or check specific codes
+      const isRetryable = error.isRetryable() ||
+                          (error.code === 'BLOCKED' && error.statusCode === 429);
 
       if (!isRetryable || attempt === maxRetries - 1) {
         throw error;
@@ -145,14 +148,12 @@ async function scrapeBatch(urls: string[]) {
 Create a structured error logger:
 
 ```typescript
-function logScrapeError(error: ScrapeError) {
+function logScrapeError(error: ScrapeError, url: string) {
+  // Use toJSON() for structured logging
   const entry = {
     timestamp: new Date().toISOString(),
-    code: error.code,
-    url: error.url,
-    message: error.message,
-    statusCode: error.statusCode,
-    stack: error.stack,
+    url,
+    ...error.toJSON(),
   };
 
   console.error(JSON.stringify(entry));
@@ -167,7 +168,7 @@ Return partial results when possible:
 ```typescript
 async function scrapeWithFallback(url: string) {
   try {
-    return await scrape(url, { enhancer });
+    return await scrape(url, { llm: provider, enhance: ['summarize'] });
   } catch (error) {
     if (error instanceof ScrapeError && error.code === 'LLM_ERROR') {
       // LLM enhancement failed, try without it
@@ -188,13 +189,13 @@ import { isValidUrl, scrape, ScrapeError } from 'scrapex';
 
 async function validateAndScrape(url: string) {
   if (!isValidUrl(url)) {
-    throw new ScrapeError('INVALID_URL', `Invalid URL: ${url}`, url);
+    throw new ScrapeError(`Invalid URL: ${url}`, 'INVALID_URL');
   }
 
   // Optionally check robots.txt first
   const robotsCheck = await checkRobotsTxt(url);
   if (!robotsCheck.allowed) {
-    throw new ScrapeError('ROBOTS_BLOCKED', 'Blocked by robots.txt', url);
+    throw new ScrapeError('Blocked by robots.txt', 'ROBOTS_BLOCKED');
   }
 
   return await scrape(url);

--- a/docs/src/content/docs/guides/llm-integration.mdx
+++ b/docs/src/content/docs/guides/llm-integration.mdx
@@ -34,51 +34,37 @@ scrapex integrates with LLM providers to enhance scraped content with AI capabil
   </TabItem>
   <TabItem label="Ollama">
     ```typescript
-    import { createOpenAI } from 'scrapex/llm';
+    import { createOllama } from 'scrapex/llm';
 
-    const ollama = createOpenAI({
-      baseURL: 'http://localhost:11434/v1',
+    const ollama = createOllama({
       model: 'llama3.2',
     });
     ```
   </TabItem>
   <TabItem label="LM Studio">
     ```typescript
-    import { createOpenAI } from 'scrapex/llm';
+    import { createLMStudio } from 'scrapex/llm';
 
-    const lmstudio = createOpenAI({
-      baseURL: 'http://localhost:1234/v1',
+    const lmstudio = createLMStudio({
       model: 'local-model',
     });
     ```
   </TabItem>
 </Tabs>
 
-## Creating an Enhancer
-
-Use `createEnhancer()` to build an enhancement pipeline:
-
-```typescript
-import { createEnhancer } from 'scrapex/llm';
-
-const enhancer = createEnhancer(openai)
-  .summarize()
-  .extractEntities()
-  .classify(['tech', 'business', 'science']);
-```
-
 ## Enhancing Scraped Content
 
-Pass the enhancer to the `scrape()` function:
+Pass the provider and enhancement types to the `scrape()` function:
 
 ```typescript
 const result = await scrape('https://example.com/article', {
-  enhancer,
+  llm: openai,
+  enhance: ['summarize', 'entities', 'tags'],
 });
 
-console.log(result.summary);     // AI-generated summary
-console.log(result.entities);    // Extracted entities
-console.log(result.categories);  // Classification results
+console.log(result.summary);        // AI-generated summary
+console.log(result.entities);       // Extracted entities
+console.log(result.suggestedTags);  // Suggested tags
 ```
 
 ## Enhancement Types
@@ -88,9 +74,7 @@ console.log(result.categories);  // Classification results
 Generate a concise summary of the content:
 
 ```typescript
-const enhancer = createEnhancer(provider).summarize();
-
-const result = await scrape(url, { enhancer });
+const result = await scrape(url, { llm: provider, enhance: ['summarize'] });
 console.log(result.summary);
 // "This article discusses the latest developments in..."
 ```
@@ -100,9 +84,7 @@ console.log(result.summary);
 Extract named entities (people, organizations, locations, etc.):
 
 ```typescript
-const enhancer = createEnhancer(provider).extractEntities();
-
-const result = await scrape(url, { enhancer });
+const result = await scrape(url, { llm: provider, enhance: ['entities'] });
 console.log(result.entities);
 // {
 //   people: ['John Smith', 'Jane Doe'],
@@ -114,15 +96,12 @@ console.log(result.entities);
 
 ### Classify
 
-Classify content into predefined categories:
+Classify content type (article, repo, docs, etc.):
 
 ```typescript
-const categories = ['technology', 'business', 'science', 'politics'];
-const enhancer = createEnhancer(provider).classify(categories);
-
-const result = await scrape(url, { enhancer });
-console.log(result.categories);
-// ['technology', 'business']
+const result = await scrape(url, { llm: provider, enhance: ['classify'] });
+console.log(result.contentType);
+// 'article', 'repo', 'docs', etc.
 ```
 
 ### Extract Structured Data
@@ -130,18 +109,15 @@ console.log(result.categories);
 Extract specific data using a JSON schema:
 
 ```typescript
-const enhancer = createEnhancer(provider).extractStructured({
-  type: 'object',
-  properties: {
-    productName: { type: 'string' },
-    price: { type: 'number' },
-    features: { type: 'array', items: { type: 'string' } },
+const result = await scrape(url, {
+  llm: provider,
+  extract: {
+    productName: 'string',
+    price: 'number',
+    features: 'string[]',
   },
-  required: ['productName', 'price'],
 });
-
-const result = await scrape(url, { enhancer });
-console.log(result.structured);
+console.log(result.extracted);
 // { productName: 'Widget Pro', price: 99.99, features: ['Fast', 'Reliable'] }
 ```
 
@@ -150,21 +126,18 @@ console.log(result.structured);
 Chain multiple enhancements together:
 
 ```typescript
-const enhancer = createEnhancer(provider)
-  .summarize()
-  .extractEntities()
-  .classify(['tech', 'news', 'tutorial'])
-  .extractStructured({
-    type: 'object',
-    properties: {
-      author: { type: 'string' },
-      topics: { type: 'array', items: { type: 'string' } },
-    },
-  });
+const result = await scrape(url, {
+  llm: provider,
+  enhance: ['summarize', 'entities', 'tags', 'classify'],
+  extract: {
+    author: 'string',
+    topics: 'string[]',
+  },
+});
 ```
 
 <Aside type="note">
-  Enhancements run sequentially in the order they're added. More enhancements = more API calls and tokens.
+  Enhancements run in parallel where possible, but each type can add additional API calls and tokens.
 </Aside>
 
 ## Token Usage
@@ -178,7 +151,8 @@ Each enhancement makes one or more LLM API calls. To minimize costs:
 ```typescript
 const result = await scrape(url, {
   maxContentLength: 10000, // Limit content to 10k chars
-  enhancer: createEnhancer(provider).summarize(),
+  llm: provider,
+  enhance: ['summarize'],
 });
 ```
 
@@ -233,7 +207,7 @@ Available placeholders:
 LLM enhancements can fail without failing the entire scrape:
 
 ```typescript
-const result = await scrape(url, { enhancer });
+const result = await scrape(url, { llm: provider, enhance: ['summarize'] });
 
 if (result.summary) {
   console.log('Summary:', result.summary);

--- a/docs/src/content/docs/guides/markdown-parsing.mdx
+++ b/docs/src/content/docs/guides/markdown-parsing.mdx
@@ -1,15 +1,15 @@
 ---
 title: Markdown Parsing
-description: Parse Markdown files for link and heading extraction.
+description: Parse Markdown files for sections, links, and code blocks.
 ---
 
 import { Aside } from '@astrojs/starlight/components';
 
-scrapex includes powerful Markdown parsing capabilities for extracting structured data from Markdown content.
+scrapex includes Markdown parsing for sections, links, and code blocks.
 
 ## MarkdownParser
 
-The `MarkdownParser` class extracts headings and links from Markdown content:
+The `MarkdownParser` class extracts sections, links, and code blocks from Markdown content:
 
 ```typescript
 import { MarkdownParser } from 'scrapex/parsers';
@@ -36,35 +36,29 @@ const result = parser.parse(markdown);
 ### Parsed Output
 
 ```typescript
-console.log(result.headings);
+console.log(result.data.sections);
 // [
-//   { level: 1, text: 'My Document' },
-//   { level: 2, text: 'Section One' },
-//   { level: 2, text: 'Section Two' },
+//   { level: 1, title: 'My Document', content: 'Check out Example for more info.', links: [...] },
+//   { level: 2, title: 'Section One', content: '', links: [...] },
+//   { level: 2, title: 'Section Two', content: 'More content with another link.', links: [...] },
 // ]
 
-console.log(result.links);
+console.log(result.data.links);
 // [
-//   { url: 'https://example.com', text: 'Example', description: '' },
-//   { url: 'https://one.com', text: 'Link 1', description: 'First link' },
-//   { url: 'https://two.com', text: 'Link 2', description: 'Second link' },
-//   { url: 'https://three.com', text: 'another link', description: '' },
+//   { url: 'https://example.com', text: 'Example', context: 'My Document' },
+//   { url: 'https://one.com', text: 'Link 1', context: 'Section One' },
+//   { url: 'https://two.com', text: 'Link 2', context: 'Section One' },
+//   { url: 'https://three.com', text: 'another link', context: 'Section Two' },
 // ]
 ```
 
-## Link Description Extraction
+## Code Blocks
 
-The parsers extract descriptions from common patterns:
+`MarkdownParser` also extracts fenced code blocks:
 
-```markdown
-- [Link](url) - Description after dash
-- [Link](url): Description after colon
-- [Link](url) — Description after em dash
-```
-
-All produce:
 ```typescript
-{ text: 'Link', url: 'url', description: 'Description after...' }
+console.log(result.data.codeBlocks);
+// [{ language: 'bash', code: 'npm install ...', meta: undefined }]
 ```
 
 ## Filtering Links
@@ -79,12 +73,12 @@ const parser = new MarkdownParser();
 const result = parser.parse(markdown);
 
 // Only GitHub links
-const githubLinks = result.links.filter(
+const githubLinks = result.data.links.filter(
   link => extractDomain(link.url) === 'github.com'
 );
 
 // Only npm packages
-const npmLinks = result.links.filter(
+const npmLinks = result.data.links.filter(
   link => link.url.includes('npmjs.com/package/')
 );
 ```

--- a/docs/src/content/docs/guides/rss-parsing.mdx
+++ b/docs/src/content/docs/guides/rss-parsing.mdx
@@ -192,9 +192,9 @@ for (const item of result.data.items) {
 
 The RSS parser includes several security measures:
 
-### HTTPS-Only URLs
+### HTTPS-Only URLs (RSS Parser Only)
 
-All URLs are resolved to HTTPS only. Non-HTTPS URLs (http, javascript, data, file) are rejected:
+The `RSSParser` resolves all URLs to HTTPS only. Non-HTTPS URLs (http, javascript, data, file) are rejected and returned as empty strings. This is specific to feed parsing to prevent malicious links in untrusted feeds:
 
 ```typescript
 const result = parser.parse(feedWithUnsafeLinks);
@@ -212,6 +212,10 @@ The parser uses Cheerio's XML mode, which doesn't process external entities or D
 
 <Aside type="caution">
   Feed content (descriptions, bodies) is returned as plain text. If you need to render HTML content, always sanitize it with a library like DOMPurify.
+</Aside>
+
+<Aside type="note">
+  The public URL utilities (`resolveUrl`, `isValidUrl`, etc.) accept both `http:` and `https:` URLs. HTTPS-only enforcement is specific to the RSS parser. Protocol-relative URLs (e.g., `//example.com/path`) are resolved against the base URL's protocol.
 </Aside>
 
 ## Next Steps

--- a/docs/src/content/docs/guides/rss-parsing.mdx
+++ b/docs/src/content/docs/guides/rss-parsing.mdx
@@ -1,0 +1,221 @@
+---
+title: RSS/Atom Feed Parsing
+description: Parse RSS 2.0, RSS 1.0 (RDF), and Atom feeds for content aggregation.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+scrapex includes a robust RSS/Atom parser for extracting structured data from syndication feeds.
+
+## RSSParser
+
+The `RSSParser` class parses RSS 2.0, RSS 1.0 (RDF), and Atom 1.0 feeds:
+
+```typescript
+import { RSSParser } from 'scrapex';
+
+const parser = new RSSParser();
+const result = parser.parse(feedXml, 'https://example.com/feed.xml');
+
+console.log(result.data.format);  // 'rss2' | 'rss1' | 'atom'
+console.log(result.data.title);   // Feed title
+console.log(result.data.items);   // Array of feed items
+```
+
+### Parsed Output
+
+```typescript
+// Feed metadata
+console.log(result.data.title);        // "My Blog"
+console.log(result.data.description);  // "A blog about..."
+console.log(result.data.link);         // "https://example.com"
+console.log(result.data.copyright);    // "Copyright 2024"
+
+// Feed items
+for (const item of result.data.items) {
+  console.log(item.title);       // "Article Title"
+  console.log(item.link);        // "https://example.com/article"
+  console.log(item.publishedAt); // "2024-09-06T16:45:00.000Z" (ISO 8601)
+  console.log(item.author);      // "John Doe"
+  console.log(item.categories);  // ["Tech", "News"]
+}
+```
+
+## Fetching Feeds
+
+Use `fetchFeed()` to fetch and parse in one call:
+
+```typescript
+import { fetchFeed } from 'scrapex';
+
+const result = await fetchFeed('https://example.com/feed.xml');
+
+for (const item of result.data.items) {
+  console.log(`${item.title} - ${item.publishedAt}`);
+}
+```
+
+<Aside type="tip">
+  `fetchFeed()` uses scrapex's fetcher infrastructure, so it respects timeouts, user agents, and other fetch options.
+</Aside>
+
+## Discovering Feeds
+
+Find RSS/Atom feed URLs in any HTML page:
+
+```typescript
+import { defaultFetcher, discoverFeeds, fetchFeed } from 'scrapex';
+
+// Fetch a page and find its feeds
+const page = await defaultFetcher.fetch('https://example.com', {});
+const feedUrls = discoverFeeds(page.html, page.finalUrl);
+// ['https://example.com/feed.xml', 'https://example.com/atom.xml']
+
+// Parse the first feed
+if (feedUrls.length > 0) {
+  const feed = await fetchFeed(feedUrls[0]);
+  console.log(feed.data.items);
+}
+```
+
+## Filtering by Date
+
+Filter feed items by date range:
+
+```typescript
+import { fetchFeed, filterByDate } from 'scrapex';
+
+const result = await fetchFeed('https://example.com/feed.xml');
+
+// Get items from the last 7 days
+const recentItems = filterByDate(result.data.items, {
+  after: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
+  includeUndated: false,
+});
+
+// Get items from a specific range
+const rangeItems = filterByDate(result.data.items, {
+  after: new Date('2024-01-01'),
+  before: new Date('2024-12-31'),
+});
+```
+
+## LLM-Ready Output
+
+Convert feeds to Markdown or plain text for LLM consumption:
+
+```typescript
+import { fetchFeed, feedToMarkdown, feedToText } from 'scrapex';
+
+const result = await fetchFeed('https://example.com/feed.xml');
+
+// Markdown format (structured)
+const markdown = feedToMarkdown(result.data, { maxItems: 5 });
+// # My Blog
+//
+// ## Article Title
+// *2024-09-06*
+//
+// Article description...
+// [Read more](https://example.com/article)
+
+// Plain text (lower tokens)
+const text = feedToText(result.data, { maxItems: 5 });
+```
+
+<Aside type="tip">
+  Use `feedToMarkdown()` when structure matters (headings, links). Use `feedToText()` for lower token counts.
+</Aside>
+
+## Pagination
+
+Some Atom feeds support pagination via `rel="next"` links (RFC 5005):
+
+```typescript
+import { paginateFeed } from 'scrapex';
+
+for await (const page of paginateFeed('https://example.com/atom', { maxPages: 5 })) {
+  console.log(`Page: ${page.title}`);
+  console.log(`Items: ${page.items.length}`);
+  console.log(`Next: ${page.next || 'none'}`);
+}
+```
+
+## Custom Fields (Podcasts)
+
+Extract custom namespace fields like iTunes podcast tags:
+
+```typescript
+import { RSSParser } from 'scrapex';
+
+const parser = new RSSParser({
+  customFields: {
+    duration: 'itunes\\:duration',
+    explicit: 'itunes\\:explicit',
+    episode: 'itunes\\:episode',
+    season: 'itunes\\:season',
+  },
+});
+
+const result = parser.parse(podcastXml, url);
+
+for (const episode of result.data.items) {
+  console.log(`Episode: ${episode.title}`);
+  console.log(`Duration: ${episode.customFields?.duration}`);
+  console.log(`S${episode.customFields?.season} E${episode.customFields?.episode}`);
+}
+```
+
+<Aside type="note">
+  Note the escaped colons (`\\:`) in namespace selectors. This is required for Cheerio's CSS selector syntax.
+</Aside>
+
+## Enclosures (Media)
+
+RSS feeds can include media attachments (podcasts, videos):
+
+```typescript
+import { fetchFeed } from 'scrapex';
+
+const result = await fetchFeed('https://example.com/podcast.xml');
+
+for (const item of result.data.items) {
+  if (item.enclosure) {
+    console.log(`Media: ${item.enclosure.url}`);
+    console.log(`Type: ${item.enclosure.type}`);   // 'audio/mpeg'
+    console.log(`Size: ${item.enclosure.length}`); // bytes
+  }
+}
+```
+
+## Security
+
+The RSS parser includes several security measures:
+
+### HTTPS-Only URLs
+
+All URLs are resolved to HTTPS only. Non-HTTPS URLs (http, javascript, data, file) are rejected:
+
+```typescript
+const result = parser.parse(feedWithUnsafeLinks);
+
+// Safe links are preserved
+console.log(result.data.items[0].link); // 'https://example.com/article'
+
+// Unsafe links become empty strings
+console.log(result.data.items[1].link); // '' (was 'javascript:alert(1)')
+```
+
+### XXE Prevention
+
+The parser uses Cheerio's XML mode, which doesn't process external entities or DTDs, preventing XXE attacks.
+
+<Aside type="caution">
+  Feed content (descriptions, bodies) is returned as plain text. If you need to render HTML content, always sanitize it with a library like DOMPurify.
+</Aside>
+
+## Next Steps
+
+- [API Reference: Parsers](/api/parsers) - Full RSSParser API documentation
+- [API Reference: Utilities](/api/utilities) - Feed utility functions
+- [LLM Integration](/guides/llm-integration) - Use feeds with LLM providers

--- a/docs/src/content/docs/guides/rss-parsing.mdx
+++ b/docs/src/content/docs/guides/rss-parsing.mdx
@@ -218,6 +218,15 @@ The parser uses Cheerio's XML mode, which doesn't process external entities or D
   The public URL utilities (`resolveUrl`, `isValidUrl`, etc.) accept both `http:` and `https:` URLs. HTTPS-only enforcement is specific to the RSS parser. Protocol-relative URLs (e.g., `//example.com/path`) are resolved against the base URL's protocol.
 </Aside>
 
+```typescript
+// Protocol-relative URLs inherit the base URL's protocol
+const result = parser.parse(feedXml, 'https://example.com/feed.xml');
+// Item link '//cdn.example.com/image.jpg' → 'https://cdn.example.com/image.jpg' ✓
+
+const result2 = parser.parse(feedXml, 'http://example.com/feed.xml');
+// Item link '//cdn.example.com/image.jpg' → '' (rejected, resolved to http)
+```
+
 ## Next Steps
 
 - [API Reference: Parsers](/api/parsers) - Full RSSParser API documentation

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -55,14 +55,14 @@ console.log(result.links);       // Extracted links
 
 ```typescript
 import { scrape } from 'scrapex';
-import { createOpenAI, createEnhancer } from 'scrapex/llm';
+import { createOpenAI } from 'scrapex/llm';
 
 const provider = createOpenAI({ apiKey: process.env.OPENAI_API_KEY });
-const enhancer = createEnhancer(provider)
-  .summarize()
-  .extractEntities();
 
-const result = await scrape('https://example.com', { enhancer });
+const result = await scrape('https://example.com', {
+  llm: provider,
+  enhance: ['summarize', 'entities'],
+});
 
 console.log(result.summary);   // AI-generated summary
 console.log(result.entities);  // Extracted entities

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,32 +1,32 @@
 {
   "name": "scrapex",
-  "version": "2.0.0",
+  "version": "1.0.0-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scrapex",
-      "version": "2.0.0",
+      "version": "1.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",
         "cheerio": "^1.1.2",
-        "jsdom": "^27.2.0",
+        "jsdom": "^27.4.0",
         "mdast-util-from-markdown": "^2.0.2",
         "mdast-util-to-string": "^4.0.0",
         "turndown": "^7.2.2",
         "unist-util-visit": "^5.0.0",
-        "zod": "^4.1.13"
+        "zod": "^4.3.4"
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.3.8",
+        "@biomejs/biome": "^2.3.10",
         "@types/jsdom": "^27.0.0",
         "@types/mdast": "^4.0.4",
         "@types/node": "^22.10.0",
         "@types/turndown": "^5.0.6",
-        "tsdown": "^0.17.0",
+        "tsdown": "^0.18.4",
         "typescript": "^5.9.3",
-        "vitest": "^4.0.15"
+        "vitest": "^4.0.16"
       },
       "engines": {
         "node": ">=20"
@@ -49,20 +49,20 @@
       }
     },
     "node_modules/@acemir/cssom": {
-      "version": "0.9.26",
-      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.26.tgz",
-      "integrity": "sha512-UMFbL3EnWH/eTvl21dz9s7Td4wYDMtxz/56zD8sL9IZGYyi48RxmdgPMiyT7R6Vn3rjMTwYZ42bqKa7ex74GEQ=="
+      "version": "0.9.30",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.30.tgz",
+      "integrity": "sha512-9CnlMCI0LmCIq0olalQqdWrJHPzm0/tw3gzOA9zJSgvFX7Xau3D24mAGa4BtwxwY69nsuJW6kQqqCzf/mEcQgg=="
     },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.0.tgz",
-      "integrity": "sha512-9xiBAtLn4aNsa4mDnpovJvBn72tNEIACyvlqaNJ+ADemR+yeMJWnBudOi2qGDviJa7SwcDOU/TRh5dnET7qk0w==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.1.tgz",
+      "integrity": "sha512-B0Hv6G3gWGMn0xKJ0txEi/jM5iFpT3MfDxmhZFb4W047GvytCf1DHQ1D69W3zHI4yWe2aTZAA0JnbMZ7Xc8DuQ==",
       "dependencies": {
         "@csstools/css-calc": "^2.1.4",
         "@csstools/css-color-parser": "^3.1.0",
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-tokenizer": "^3.0.4",
-        "lru-cache": "^11.2.2"
+        "lru-cache": "^11.2.4"
       }
     },
     "node_modules/@asamuzakjp/dom-selector": {
@@ -145,9 +145,9 @@
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.3.8.tgz",
-      "integrity": "sha512-Qjsgoe6FEBxWAUzwFGFrB+1+M8y/y5kwmg5CHac+GSVOdmOIqsAiXM5QMVGZJ1eCUCLlPZtq4aFAQ0eawEUuUA==",
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.3.10.tgz",
+      "integrity": "sha512-/uWSUd1MHX2fjqNLHNL6zLYWBbrJeG412/8H7ESuK8ewoRoMPUgHDebqKrPTx/5n6f17Xzqc9hdg3MEqA5hXnQ==",
       "dev": true,
       "bin": {
         "biome": "bin/biome"
@@ -160,20 +160,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "2.3.8",
-        "@biomejs/cli-darwin-x64": "2.3.8",
-        "@biomejs/cli-linux-arm64": "2.3.8",
-        "@biomejs/cli-linux-arm64-musl": "2.3.8",
-        "@biomejs/cli-linux-x64": "2.3.8",
-        "@biomejs/cli-linux-x64-musl": "2.3.8",
-        "@biomejs/cli-win32-arm64": "2.3.8",
-        "@biomejs/cli-win32-x64": "2.3.8"
+        "@biomejs/cli-darwin-arm64": "2.3.10",
+        "@biomejs/cli-darwin-x64": "2.3.10",
+        "@biomejs/cli-linux-arm64": "2.3.10",
+        "@biomejs/cli-linux-arm64-musl": "2.3.10",
+        "@biomejs/cli-linux-x64": "2.3.10",
+        "@biomejs/cli-linux-x64-musl": "2.3.10",
+        "@biomejs/cli-win32-arm64": "2.3.10",
+        "@biomejs/cli-win32-x64": "2.3.10"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.3.8.tgz",
-      "integrity": "sha512-HM4Zg9CGQ3txTPflxD19n8MFPrmUAjaC7PQdLkugeeC0cQ+PiVrd7i09gaBS/11QKsTDBJhVg85CEIK9f50Qww==",
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.3.10.tgz",
+      "integrity": "sha512-M6xUjtCVnNGFfK7HMNKa593nb7fwNm43fq1Mt71kpLpb+4mE7odO8W/oWVDyBVO4ackhresy1ZYO7OJcVo/B7w==",
       "cpu": [
         "arm64"
       ],
@@ -187,9 +187,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.3.8.tgz",
-      "integrity": "sha512-lUDQ03D7y/qEao7RgdjWVGCu+BLYadhKTm40HkpJIi6kn8LSv5PAwRlew/DmwP4YZ9ke9XXoTIQDO1vAnbRZlA==",
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.3.10.tgz",
+      "integrity": "sha512-Vae7+V6t/Avr8tVbFNjnFSTKZogZHFYl7MMH62P/J1kZtr0tyRQ9Fe0onjqjS2Ek9lmNLmZc/VR5uSekh+p1fg==",
       "cpu": [
         "x64"
       ],
@@ -203,9 +203,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.3.8.tgz",
-      "integrity": "sha512-Uo1OJnIkJgSgF+USx970fsM/drtPcQ39I+JO+Fjsaa9ZdCN1oysQmy6oAGbyESlouz+rzEckLTF6DS7cWse95g==",
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.3.10.tgz",
+      "integrity": "sha512-hhPw2V3/EpHKsileVOFynuWiKRgFEV48cLe0eA+G2wO4SzlwEhLEB9LhlSrVeu2mtSn205W283LkX7Fh48CaxA==",
       "cpu": [
         "arm64"
       ],
@@ -219,9 +219,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.3.8.tgz",
-      "integrity": "sha512-PShR4mM0sjksUMyxbyPNMxoKFPVF48fU8Qe8Sfx6w6F42verbwRLbz+QiKNiDPRJwUoMG1nPM50OBL3aOnTevA==",
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.3.10.tgz",
+      "integrity": "sha512-B9DszIHkuKtOH2IFeeVkQmSMVUjss9KtHaNXquYYWCjH8IstNgXgx5B0aSBQNr6mn4RcKKRQZXn9Zu1rM3O0/A==",
       "cpu": [
         "arm64"
       ],
@@ -235,9 +235,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.3.8.tgz",
-      "integrity": "sha512-QDPMD5bQz6qOVb3kiBui0zKZXASLo0NIQ9JVJio5RveBEFgDgsvJFUvZIbMbUZT3T00M/1wdzwWXk4GIh0KaAw==",
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.3.10.tgz",
+      "integrity": "sha512-wwAkWD1MR95u+J4LkWP74/vGz+tRrIQvr8kfMMJY8KOQ8+HMVleREOcPYsQX82S7uueco60L58Wc6M1I9WA9Dw==",
       "cpu": [
         "x64"
       ],
@@ -251,9 +251,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.3.8.tgz",
-      "integrity": "sha512-YGLkqU91r1276uwSjiUD/xaVikdxgV1QpsicT0bIA1TaieM6E5ibMZeSyjQ/izBn4tKQthUSsVZacmoJfa3pDA==",
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.3.10.tgz",
+      "integrity": "sha512-QTfHZQh62SDFdYc2nfmZFuTm5yYb4eO1zwfB+90YxUumRCR171tS1GoTX5OD0wrv4UsziMPmrePMtkTnNyYG3g==",
       "cpu": [
         "x64"
       ],
@@ -267,9 +267,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.3.8.tgz",
-      "integrity": "sha512-H4IoCHvL1fXKDrTALeTKMiE7GGWFAraDwBYFquE/L/5r1927Te0mYIGseXi4F+lrrwhSWbSGt5qPFswNoBaCxg==",
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.3.10.tgz",
+      "integrity": "sha512-o7lYc9n+CfRbHvkjPhm8s9FgbKdYZu5HCcGVMItLjz93EhgJ8AM44W+QckDqLA9MKDNFrR8nPbO4b73VC5kGGQ==",
       "cpu": [
         "arm64"
       ],
@@ -283,9 +283,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.3.8.tgz",
-      "integrity": "sha512-RguzimPoZWtBapfKhKjcWXBVI91tiSprqdBYu7tWhgN8pKRZhw24rFeNZTNf6UiBfjCYCi9eFQs/JzJZIhuK4w==",
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.3.10.tgz",
+      "integrity": "sha512-pHEFgq7dUEsKnqG9mx9bXihxGI49X+ar+UBrEIj3Wqj3UCZp1rNgV+OoyjFgcXsjCWpuEAF4VJdkZr3TrWdCbQ==",
       "cpu": [
         "x64"
       ],
@@ -386,9 +386,9 @@
       }
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.0.20",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.20.tgz",
-      "integrity": "sha512-8BHsjXfSciZxjmHQOuVdW2b8WLUPts9a+mfL13/PzEviufUEW2xnvQuOlKs9dRBHgRqJ53SF/DUoK9+MZk72oQ==",
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.22.tgz",
+      "integrity": "sha512-qBcx6zYlhleiFfdtzkRgwNC7VVoAwfK76Vmsw5t+PbvtdknO9StgRk7ROvq9so1iqbdW4uLIDAsXRsTfUrIoOw==",
       "funding": [
         {
           "type": "github",
@@ -453,9 +453,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
-      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
+      "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
       "cpu": [
         "ppc64"
       ],
@@ -469,9 +469,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
-      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
+      "integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
       "cpu": [
         "arm"
       ],
@@ -485,9 +485,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
-      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
+      "integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
       "cpu": [
         "arm64"
       ],
@@ -501,9 +501,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
-      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
+      "integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
       "cpu": [
         "x64"
       ],
@@ -517,9 +517,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
-      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
+      "integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
       "cpu": [
         "arm64"
       ],
@@ -533,9 +533,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
-      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
+      "integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
       "cpu": [
         "x64"
       ],
@@ -549,9 +549,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
       "cpu": [
         "arm64"
       ],
@@ -565,9 +565,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
-      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
+      "integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
       "cpu": [
         "x64"
       ],
@@ -581,9 +581,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
-      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
+      "integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
       "cpu": [
         "arm"
       ],
@@ -597,9 +597,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
-      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
+      "integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
       "cpu": [
         "arm64"
       ],
@@ -613,9 +613,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
-      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
+      "integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
       "cpu": [
         "ia32"
       ],
@@ -629,9 +629,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
-      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
+      "integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
       "cpu": [
         "loong64"
       ],
@@ -645,9 +645,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
-      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
+      "integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
       "cpu": [
         "mips64el"
       ],
@@ -661,9 +661,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
-      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
+      "integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
       "cpu": [
         "ppc64"
       ],
@@ -677,9 +677,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
-      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
+      "integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
       "cpu": [
         "riscv64"
       ],
@@ -693,9 +693,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
-      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
+      "integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
       "cpu": [
         "s390x"
       ],
@@ -709,9 +709,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
-      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
+      "integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
       "cpu": [
         "x64"
       ],
@@ -725,9 +725,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
       "cpu": [
         "arm64"
       ],
@@ -741,9 +741,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
+      "integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
       "cpu": [
         "x64"
       ],
@@ -757,9 +757,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
       "cpu": [
         "arm64"
       ],
@@ -773,9 +773,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
+      "integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
       "cpu": [
         "x64"
       ],
@@ -789,9 +789,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
-      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
+      "integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
       "cpu": [
         "arm64"
       ],
@@ -805,9 +805,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
-      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
+      "integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
       "cpu": [
         "x64"
       ],
@@ -821,9 +821,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
-      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
+      "integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
       "cpu": [
         "arm64"
       ],
@@ -837,9 +837,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
-      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
+      "integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
       "cpu": [
         "ia32"
       ],
@@ -853,9 +853,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
-      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
+      "integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
       "cpu": [
         "x64"
       ],
@@ -866,6 +866,22 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.7.0.tgz",
+      "integrity": "sha512-5i+BtvujK/vM07YCGDyz4C4AyDzLmhxHMtM5HpUyPRtJPBdFPsj290ffXW+UXY21/G7GtXeHD2nRmq0T1ShyQQ==",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@exodus/crypto": "^1.0.0-rc.4"
+      },
+      "peerDependenciesMeta": {
+        "@exodus/crypto": {
+          "optional": true
+        }
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -917,30 +933,25 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.0.tgz",
-      "integrity": "sha512-Fq6DJW+Bb5jaWE69/qOE0D1TUN9+6uWhCeZpdnSBk14pjLcCWR7Q8n49PTSPHazM37JqrsdpEthXy2xn6jWWiA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
+      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
       "dev": true,
       "optional": true,
       "dependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1",
         "@tybys/wasm-util": "^0.10.1"
-      }
-    },
-    "node_modules/@oxc-project/runtime": {
-      "version": "0.101.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.101.0.tgz",
-      "integrity": "sha512-t3qpfVZIqSiLQ5Kqt/MC4Ge/WCOGrrcagAdzTcDaggupjiGxUx4nJF2v6wUCXWSzWHn5Ns7XLv13fCJEwCOERQ==",
-      "dev": true,
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.101.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.101.0.tgz",
-      "integrity": "sha512-nuFhqlUzJX+gVIPPfuE6xurd4lST3mdcWOhyK/rZO0B9XWMKm79SuszIQEnSMmmDhq1DC8WWVYGVd+6F93o1gQ==",
+      "version": "0.103.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.103.0.tgz",
+      "integrity": "sha512-bkiYX5kaXWwUessFRSoXFkGIQTmc6dLGdxuRTrC+h8PSnIdZyuXHHlLAeTmOue5Br/a0/a7dHH0Gca6eXn9MKg==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
@@ -959,9 +970,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-beta.53",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-beta.53.tgz",
-      "integrity": "sha512-Ok9V8o7o6YfSdTTYA/uHH30r3YtOxLD6G3wih/U9DO0ucBBFq8WPt/DslU53OgfteLRHITZny9N/qCUxMf9kjQ==",
+      "version": "1.0.0-beta.57",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-beta.57.tgz",
+      "integrity": "sha512-GoOVDy8bjw9z1K30Oo803nSzXJS/vWhFijFsW3kzvZCO8IZwFnNa6pGctmbbJstKl3Fv6UBwyjJQN6msejW0IQ==",
       "cpu": [
         "arm64"
       ],
@@ -975,9 +986,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-beta.53",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-beta.53.tgz",
-      "integrity": "sha512-yIsKqMz0CtRnVa6x3Pa+mzTihr4Ty+Z6HfPbZ7RVbk1Uxnco4+CUn7Qbm/5SBol1JD/7nvY8rphAgyAi7Lj6Vg==",
+      "version": "1.0.0-beta.57",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-beta.57.tgz",
+      "integrity": "sha512-9c4FOhRGpl+PX7zBK5p17c5efpF9aSpTPgyigv57hXf5NjQUaJOOiejPLAtFiKNBIfm5Uu6yFkvLKzOafNvlTw==",
       "cpu": [
         "arm64"
       ],
@@ -991,9 +1002,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-beta.53",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-beta.53.tgz",
-      "integrity": "sha512-GTXe+mxsCGUnJOFMhfGWmefP7Q9TpYUseHvhAhr21nCTgdS8jPsvirb0tJwM3lN0/u/cg7bpFNa16fQrjKrCjQ==",
+      "version": "1.0.0-beta.57",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-beta.57.tgz",
+      "integrity": "sha512-6RsB8Qy4LnGqNGJJC/8uWeLWGOvbRL/KG5aJ8XXpSEupg/KQtlBEiFaYU/Ma5Usj1s+bt3ItkqZYAI50kSplBA==",
       "cpu": [
         "x64"
       ],
@@ -1007,9 +1018,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-beta.53",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-beta.53.tgz",
-      "integrity": "sha512-9Tmp7bBvKqyDkMcL4e089pH3RsjD3SUungjmqWtyhNOxoQMh0fSmINTyYV8KXtE+JkxYMPWvnEt+/mfpVCkk8w==",
+      "version": "1.0.0-beta.57",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-beta.57.tgz",
+      "integrity": "sha512-uA9kG7+MYkHTbqwv67Tx+5GV5YcKd33HCJIi0311iYBd25yuwyIqvJfBdt1VVB8tdOlyTb9cPAgfCki8nhwTQg==",
       "cpu": [
         "x64"
       ],
@@ -1023,9 +1034,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-beta.53",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-beta.53.tgz",
-      "integrity": "sha512-a1y5fiB0iovuzdbjUxa7+Zcvgv+mTmlGGC4XydVIsyl48eoxgaYkA3l9079hyTyhECsPq+mbr0gVQsFU11OJAQ==",
+      "version": "1.0.0-beta.57",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-beta.57.tgz",
+      "integrity": "sha512-3KkS0cHsllT2T+Te+VZMKHNw6FPQihYsQh+8J4jkzwgvAQpbsbXmrqhkw3YU/QGRrD8qgcOvBr6z5y6Jid+rmw==",
       "cpu": [
         "arm"
       ],
@@ -1039,9 +1050,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-beta.53",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-beta.53.tgz",
-      "integrity": "sha512-bpIGX+ov9PhJYV+wHNXl9rzq4F0QvILiURn0y0oepbQx+7stmQsKA0DhPGwmhfvF856wq+gbM8L92SAa/CBcLg==",
+      "version": "1.0.0-beta.57",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-beta.57.tgz",
+      "integrity": "sha512-A3/wu1RgsHhqP3rVH2+sM81bpk+Qd2XaHTl8LtX5/1LNR7QVBFBCpAoiXwjTdGnI5cMdBVi7Z1pi52euW760Fw==",
       "cpu": [
         "arm64"
       ],
@@ -1055,9 +1066,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-beta.53",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-beta.53.tgz",
-      "integrity": "sha512-bGe5EBB8FVjHBR1mOLOPEFg1Lp3//7geqWkU5NIhxe+yH0W8FVrQ6WRYOap4SUTKdklD/dC4qPLREkMMQ855FA==",
+      "version": "1.0.0-beta.57",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-beta.57.tgz",
+      "integrity": "sha512-d0kIVezTQtazpyWjiJIn5to8JlwfKITDqwsFv0Xc6s31N16CD2PC/Pl2OtKgS7n8WLOJbfqgIp5ixYzTAxCqMg==",
       "cpu": [
         "arm64"
       ],
@@ -1071,9 +1082,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-beta.53",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-beta.53.tgz",
-      "integrity": "sha512-qL+63WKVQs1CMvFedlPt0U9PiEKJOAL/bsHMKUDS6Vp2Q+YAv/QLPu8rcvkfIMvQ0FPU2WL0aX4eWwF6e/GAnA==",
+      "version": "1.0.0-beta.57",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-beta.57.tgz",
+      "integrity": "sha512-E199LPijo98yrLjPCmETx8EF43sZf9t3guSrLee/ej1rCCc3zDVTR4xFfN9BRAapGVl7/8hYqbbiQPTkv73kUg==",
       "cpu": [
         "x64"
       ],
@@ -1087,9 +1098,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-beta.53",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-beta.53.tgz",
-      "integrity": "sha512-VGl9JIGjoJh3H8Mb+7xnVqODajBmrdOOb9lxWXdcmxyI+zjB2sux69br0hZJDTyLJfvBoYm439zPACYbCjGRmw==",
+      "version": "1.0.0-beta.57",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-beta.57.tgz",
+      "integrity": "sha512-++EQDpk/UJ33kY/BNsh7A7/P1sr/jbMuQ8cE554ZIy+tCUWCivo9zfyjDUoiMdnxqX6HLJEqqGnbGQOvzm2OMQ==",
       "cpu": [
         "x64"
       ],
@@ -1103,9 +1114,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-beta.53",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-beta.53.tgz",
-      "integrity": "sha512-B4iIserJXuSnNzA5xBLFUIjTfhNy7d9sq4FUMQY3GhQWGVhS2RWWzzDnkSU6MUt7/aHUrep0CdQfXUJI9D3W7A==",
+      "version": "1.0.0-beta.57",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-beta.57.tgz",
+      "integrity": "sha512-voDEBcNqxbUv/GeXKFtxXVWA+H45P/8Dec4Ii/SbyJyGvCqV1j+nNHfnFUIiRQ2Q40DwPe/djvgYBs9PpETiMA==",
       "cpu": [
         "arm64"
       ],
@@ -1119,9 +1130,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-beta.53",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-beta.53.tgz",
-      "integrity": "sha512-BUjAEgpABEJXilGq/BPh7jeU3WAJ5o15c1ZEgHaDWSz3LB881LQZnbNJHmUiM4d1JQWMYYyR1Y490IBHi2FPJg==",
+      "version": "1.0.0-beta.57",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-beta.57.tgz",
+      "integrity": "sha512-bRhcF7NLlCnpkzLVlVhrDEd0KH22VbTPkPTbMjlYvqhSmarxNIq5vtlQS8qmV7LkPKHrNLWyJW/V/sOyFba26Q==",
       "cpu": [
         "wasm32"
       ],
@@ -1135,9 +1146,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-beta.53",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-beta.53.tgz",
-      "integrity": "sha512-s27uU7tpCWSjHBnxyVXHt3rMrQdJq5MHNv3BzsewCIroIw3DJFjMH1dzCPPMUFxnh1r52Nf9IJ/eWp6LDoyGcw==",
+      "version": "1.0.0-beta.57",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-beta.57.tgz",
+      "integrity": "sha512-rnDVGRks2FQ2hgJ2g15pHtfxqkGFGjJQUDWzYznEkE8Ra2+Vag9OffxdbJMZqBWXHVM0iS4dv8qSiEn7bO+n1Q==",
       "cpu": [
         "arm64"
       ],
@@ -1151,9 +1162,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-beta.53",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-beta.53.tgz",
-      "integrity": "sha512-cjWL/USPJ1g0en2htb4ssMjIycc36RvdQAx1WlXnS6DpULswiUTVXPDesTifSKYSyvx24E0YqQkEm0K/M2Z/AA==",
+      "version": "1.0.0-beta.57",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-beta.57.tgz",
+      "integrity": "sha512-OqIUyNid1M4xTj6VRXp/Lht/qIP8fo25QyAZlCP+p6D2ATCEhyW4ZIFLnC9zAGN/HMbXoCzvwfa8Jjg/8J4YEg==",
       "cpu": [
         "x64"
       ],
@@ -1167,15 +1178,15 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-beta.53",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.53.tgz",
-      "integrity": "sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ==",
+      "version": "1.0.0-beta.57",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.57.tgz",
+      "integrity": "sha512-aQNelgx14tGA+n2tNSa9x6/jeoCL9fkDeCei7nOKnHx0fEFRRMu5ReiITo+zZD5TzWDGGRjbSYCs93IfRIyTuQ==",
       "dev": true
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.53.3.tgz",
-      "integrity": "sha512-mRSi+4cBjrRLoaal2PnqH82Wqyb+d3HsPUN/W+WslCXsZsyHa9ZeQQX/pQsZaVIWDkPcpV6jJ+3KLbTbgnwv8w==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.54.0.tgz",
+      "integrity": "sha512-OywsdRHrFvCdvsewAInDKCNyR3laPA2mc9bRYJ6LBp5IyvF3fvXbbNR0bSzHlZVFtn6E0xw2oZlyjg4rKCVcng==",
       "cpu": [
         "arm"
       ],
@@ -1186,9 +1197,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.53.3.tgz",
-      "integrity": "sha512-CbDGaMpdE9sh7sCmTrTUyllhrg65t6SwhjlMJsLr+J8YjFuPmCEjbBSx4Z/e4SmDyH3aB5hGaJUP2ltV/vcs4w==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.54.0.tgz",
+      "integrity": "sha512-Skx39Uv+u7H224Af+bDgNinitlmHyQX1K/atIA32JP3JQw6hVODX5tkbi2zof/E69M1qH2UoN3Xdxgs90mmNYw==",
       "cpu": [
         "arm64"
       ],
@@ -1199,9 +1210,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.53.3.tgz",
-      "integrity": "sha512-Nr7SlQeqIBpOV6BHHGZgYBuSdanCXuw09hon14MGOLGmXAFYjx1wNvquVPmpZnl0tLjg25dEdr4IQ6GgyToCUA==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.54.0.tgz",
+      "integrity": "sha512-k43D4qta/+6Fq+nCDhhv9yP2HdeKeP56QrUUTW7E6PhZP1US6NDqpJj4MY0jBHlJivVJD5P8NxrjuobZBJTCRw==",
       "cpu": [
         "arm64"
       ],
@@ -1212,9 +1223,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.53.3.tgz",
-      "integrity": "sha512-DZ8N4CSNfl965CmPktJ8oBnfYr3F8dTTNBQkRlffnUarJ2ohudQD17sZBa097J8xhQ26AwhHJ5mvUyQW8ddTsQ==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.54.0.tgz",
+      "integrity": "sha512-cOo7biqwkpawslEfox5Vs8/qj83M/aZCSSNIWpVzfU2CYHa2G3P1UN5WF01RdTHSgCkri7XOlTdtk17BezlV3A==",
       "cpu": [
         "x64"
       ],
@@ -1225,9 +1236,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.53.3.tgz",
-      "integrity": "sha512-yMTrCrK92aGyi7GuDNtGn2sNW+Gdb4vErx4t3Gv/Tr+1zRb8ax4z8GWVRfr3Jw8zJWvpGHNpss3vVlbF58DZ4w==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.54.0.tgz",
+      "integrity": "sha512-miSvuFkmvFbgJ1BevMa4CPCFt5MPGw094knM64W9I0giUIMMmRYcGW/JWZDriaw/k1kOBtsWh1z6nIFV1vPNtA==",
       "cpu": [
         "arm64"
       ],
@@ -1238,9 +1249,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.53.3.tgz",
-      "integrity": "sha512-lMfF8X7QhdQzseM6XaX0vbno2m3hlyZFhwcndRMw8fbAGUGL3WFMBdK0hbUBIUYcEcMhVLr1SIamDeuLBnXS+Q==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.54.0.tgz",
+      "integrity": "sha512-KGXIs55+b/ZfZsq9aR026tmr/+7tq6VG6MsnrvF4H8VhwflTIuYh+LFUlIsRdQSgrgmtM3fVATzEAj4hBQlaqQ==",
       "cpu": [
         "x64"
       ],
@@ -1251,9 +1262,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.53.3.tgz",
-      "integrity": "sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.54.0.tgz",
+      "integrity": "sha512-EHMUcDwhtdRGlXZsGSIuXSYwD5kOT9NVnx9sqzYiwAc91wfYOE1g1djOEDseZJKKqtHAHGwnGPQu3kytmfaXLQ==",
       "cpu": [
         "arm"
       ],
@@ -1264,9 +1275,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.53.3.tgz",
-      "integrity": "sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.54.0.tgz",
+      "integrity": "sha512-+pBrqEjaakN2ySv5RVrj/qLytYhPKEUwk+e3SFU5jTLHIcAtqh2rLrd/OkbNuHJpsBgxsD8ccJt5ga/SeG0JmA==",
       "cpu": [
         "arm"
       ],
@@ -1277,9 +1288,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.53.3.tgz",
-      "integrity": "sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.54.0.tgz",
+      "integrity": "sha512-NSqc7rE9wuUaRBsBp5ckQ5CVz5aIRKCwsoa6WMF7G01sX3/qHUw/z4pv+D+ahL1EIKy6Enpcnz1RY8pf7bjwng==",
       "cpu": [
         "arm64"
       ],
@@ -1290,9 +1301,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.53.3.tgz",
-      "integrity": "sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.54.0.tgz",
+      "integrity": "sha512-gr5vDbg3Bakga5kbdpqx81m2n9IX8M6gIMlQQIXiLTNeQW6CucvuInJ91EuCJ/JYvc+rcLLsDFcfAD1K7fMofg==",
       "cpu": [
         "arm64"
       ],
@@ -1303,9 +1314,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.53.3.tgz",
-      "integrity": "sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.54.0.tgz",
+      "integrity": "sha512-gsrtB1NA3ZYj2vq0Rzkylo9ylCtW/PhpLEivlgWe0bpgtX5+9j9EZa0wtZiCjgu6zmSeZWyI/e2YRX1URozpIw==",
       "cpu": [
         "loong64"
       ],
@@ -1316,9 +1327,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.53.3.tgz",
-      "integrity": "sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.54.0.tgz",
+      "integrity": "sha512-y3qNOfTBStmFNq+t4s7Tmc9hW2ENtPg8FeUD/VShI7rKxNW7O4fFeaYbMsd3tpFlIg1Q8IapFgy7Q9i2BqeBvA==",
       "cpu": [
         "ppc64"
       ],
@@ -1329,9 +1340,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.53.3.tgz",
-      "integrity": "sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.54.0.tgz",
+      "integrity": "sha512-89sepv7h2lIVPsFma8iwmccN7Yjjtgz0Rj/Ou6fEqg3HDhpCa+Et+YSufy27i6b0Wav69Qv4WBNl3Rs6pwhebQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1342,9 +1353,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.53.3.tgz",
-      "integrity": "sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.54.0.tgz",
+      "integrity": "sha512-ZcU77ieh0M2Q8Ur7D5X7KvK+UxbXeDHwiOt/CPSBTI1fBmeDMivW0dPkdqkT4rOgDjrDDBUed9x4EgraIKoR2A==",
       "cpu": [
         "riscv64"
       ],
@@ -1355,9 +1366,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.53.3.tgz",
-      "integrity": "sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.54.0.tgz",
+      "integrity": "sha512-2AdWy5RdDF5+4YfG/YesGDDtbyJlC9LHmL6rZw6FurBJ5n4vFGupsOBGfwMRjBYH7qRQowT8D/U4LoSvVwOhSQ==",
       "cpu": [
         "s390x"
       ],
@@ -1368,9 +1379,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.53.3.tgz",
-      "integrity": "sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.54.0.tgz",
+      "integrity": "sha512-WGt5J8Ij/rvyqpFexxk3ffKqqbLf9AqrTBbWDk7ApGUzaIs6V+s2s84kAxklFwmMF/vBNGrVdYgbblCOFFezMQ==",
       "cpu": [
         "x64"
       ],
@@ -1381,9 +1392,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.53.3.tgz",
-      "integrity": "sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.54.0.tgz",
+      "integrity": "sha512-JzQmb38ATzHjxlPHuTH6tE7ojnMKM2kYNzt44LO/jJi8BpceEC8QuXYA908n8r3CNuG/B3BV8VR3Hi1rYtmPiw==",
       "cpu": [
         "x64"
       ],
@@ -1394,9 +1405,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.53.3.tgz",
-      "integrity": "sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.54.0.tgz",
+      "integrity": "sha512-huT3fd0iC7jigGh7n3q/+lfPcXxBi+om/Rs3yiFxjvSxbSB6aohDFXbWvlspaqjeOh+hx7DDHS+5Es5qRkWkZg==",
       "cpu": [
         "arm64"
       ],
@@ -1407,9 +1418,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.53.3.tgz",
-      "integrity": "sha512-GOFuKpsxR/whszbF/bzydebLiXIHSgsEUp6M0JI8dWvi+fFa1TD6YQa4aSZHtpmh2/uAlj/Dy+nmby3TJ3pkTw==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.54.0.tgz",
+      "integrity": "sha512-c2V0W1bsKIKfbLMBu/WGBz6Yci8nJ/ZJdheE0EwB73N3MvHYKiKGs3mVilX4Gs70eGeDaMqEob25Tw2Gb9Nqyw==",
       "cpu": [
         "arm64"
       ],
@@ -1420,9 +1431,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.53.3.tgz",
-      "integrity": "sha512-iah+THLcBJdpfZ1TstDFbKNznlzoxa8fmnFYK4V67HvmuNYkVdAywJSoteUszvBQ9/HqN2+9AZghbajMsFT+oA==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.54.0.tgz",
+      "integrity": "sha512-woEHgqQqDCkAzrDhvDipnSirm5vxUXtSKDYTVpZG3nUdW/VVB5VdCYA2iReSj/u3yCZzXID4kuKG7OynPnB3WQ==",
       "cpu": [
         "ia32"
       ],
@@ -1433,9 +1444,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.53.3.tgz",
-      "integrity": "sha512-J9QDiOIZlZLdcot5NXEepDkstocktoVjkaKUtqzgzpt2yWjGlbYiKyp05rWwk4nypbYUNoFAztEgixoLaSETkg==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.54.0.tgz",
+      "integrity": "sha512-dzAc53LOuFvHwbCEOS0rPbXp6SIhAf2txMP5p6mGyOXXw5mWY8NGGbPMPrs4P1WItkfApDathBj/NzMLUZ9rtQ==",
       "cpu": [
         "x64"
       ],
@@ -1446,9 +1457,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.53.3.tgz",
-      "integrity": "sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.54.0.tgz",
+      "integrity": "sha512-hYT5d3YNdSh3mbCU1gwQyPgQd3T2ne0A3KG8KSBdav5TiBg6eInVmV+TeR5uHufiIgSFg0XsOWGW5/RhNcSvPg==",
       "cpu": [
         "x64"
       ],
@@ -1459,9 +1470,9 @@
       ]
     },
     "node_modules/@standard-schema/spec": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
-      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true
     },
     "node_modules/@tybys/wasm-util": {
@@ -1555,15 +1566,15 @@
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
     },
     "node_modules/@vitest/expect": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.15.tgz",
-      "integrity": "sha512-Gfyva9/GxPAWXIWjyGDli9O+waHDC0Q0jaLdFP1qPAUUfo1FEXPXUfUkp3eZA0sSq340vPycSyOlYUeM15Ft1w==",
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.16.tgz",
+      "integrity": "sha512-eshqULT2It7McaJkQGLkPjPjNph+uevROGuIMJdG3V+0BSR2w9u6J9Lwu+E8cK5TETlfou8GRijhafIMhXsimA==",
       "dev": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.0.15",
-        "@vitest/utils": "4.0.15",
+        "@vitest/spy": "4.0.16",
+        "@vitest/utils": "4.0.16",
         "chai": "^6.2.1",
         "tinyrainbow": "^3.0.3"
       },
@@ -1572,12 +1583,12 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.15.tgz",
-      "integrity": "sha512-CZ28GLfOEIFkvCFngN8Sfx5h+Se0zN+h4B7yOsPVCcgtiO7t5jt9xQh2E1UkFep+eb9fjyMfuC5gBypwb07fvQ==",
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.16.tgz",
+      "integrity": "sha512-yb6k4AZxJTB+q9ycAvsoxGn+j/po0UaPgajllBgt1PzoMAAmJGYFdDk0uCcRcxb3BrME34I6u8gHZTQlkqSZpg==",
       "dev": true,
       "dependencies": {
-        "@vitest/spy": "4.0.15",
+        "@vitest/spy": "4.0.16",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -1598,9 +1609,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.15.tgz",
-      "integrity": "sha512-SWdqR8vEv83WtZcrfLNqlqeQXlQLh2iilO1Wk1gv4eiHKjEzvgHb2OVc3mIPyhZE6F+CtfYjNlDJwP5MN6Km7A==",
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.16.tgz",
+      "integrity": "sha512-eNCYNsSty9xJKi/UdVD8Ou16alu7AYiS2fCPRs0b1OdhJiV89buAXQLpTbe+X8V9L6qrs9CqyvU7OaAopJYPsA==",
       "dev": true,
       "dependencies": {
         "tinyrainbow": "^3.0.3"
@@ -1610,12 +1621,12 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.15.tgz",
-      "integrity": "sha512-+A+yMY8dGixUhHmNdPUxOh0la6uVzun86vAbuMT3hIDxMrAOmn5ILBHm8ajrqHE0t8R9T1dGnde1A5DTnmi3qw==",
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.16.tgz",
+      "integrity": "sha512-VWEDm5Wv9xEo80ctjORcTQRJ539EGPB3Pb9ApvVRAY1U/WkHXmmYISqU5E79uCwcW7xYUV38gwZD+RV755fu3Q==",
       "dev": true,
       "dependencies": {
-        "@vitest/utils": "4.0.15",
+        "@vitest/utils": "4.0.16",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1623,12 +1634,12 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.15.tgz",
-      "integrity": "sha512-A7Ob8EdFZJIBjLjeO0DZF4lqR6U7Ydi5/5LIZ0xcI+23lYlsYJAfGn8PrIWTYdZQRNnSRlzhg0zyGu37mVdy5g==",
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.16.tgz",
+      "integrity": "sha512-sf6NcrYhYBsSYefxnry+DR8n3UV4xWZwWxYbCJUt2YdvtqzSPR7VfGrY0zsv090DAbjFZsi7ZaMi1KnSRyK1XA==",
       "dev": true,
       "dependencies": {
-        "@vitest/pretty-format": "4.0.15",
+        "@vitest/pretty-format": "4.0.16",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -1637,21 +1648,21 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.15.tgz",
-      "integrity": "sha512-+EIjOJmnY6mIfdXtE/bnozKEvTC4Uczg19yeZ2vtCz5Yyb0QQ31QWVQ8hswJ3Ysx/K2EqaNsVanjr//2+P3FHw==",
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.16.tgz",
+      "integrity": "sha512-4jIOWjKP0ZUaEmJm00E0cOBLU+5WE0BpeNr3XN6TEF05ltro6NJqHWxXD0kA8/Zc8Nh23AT8WQxwNG+WeROupw==",
       "dev": true,
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.15.tgz",
-      "integrity": "sha512-HXjPW2w5dxhTD0dLwtYHDnelK3j8sR8cWIaLxr22evTyY6q8pRCjZSmhRWVjBaOVXChQd6AwMzi9pucorXCPZA==",
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.16.tgz",
+      "integrity": "sha512-h8z9yYhV3e1LEfaQ3zdypIrnAg/9hguReGZoS7Gl0aBG5xgA410zBqECqmaF/+RkTggRsfnzc1XaAHA6bmUufA==",
       "dev": true,
       "dependencies": {
-        "@vitest/pretty-format": "4.0.15",
+        "@vitest/pretty-format": "4.0.16",
         "tinyrainbow": "^3.0.3"
       },
       "funding": {
@@ -1709,9 +1720,9 @@
       }
     },
     "node_modules/birpc": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/birpc/-/birpc-3.0.0.tgz",
-      "integrity": "sha512-by+04pHuxpCEQcucAXqzopqfhyI8TLK5Qg5MST0cB6MP+JhHna9ollrtK9moVh27aq6Q6MEJgebD0cVm//yBkg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-4.0.0.tgz",
+      "integrity": "sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/antfu"
@@ -1732,9 +1743,9 @@
       }
     },
     "node_modules/chai": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.1.tgz",
-      "integrity": "sha512-p4Z49OGG5W/WBCPSS/dH3jQ73kD6tiMmUM+bckNK6Jr5JHMG3k9bg/BvKR8lKmtVBKmOiuVaV2ws8s9oSbwysg==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "engines": {
         "node": ">=18"
@@ -1828,13 +1839,14 @@
       }
     },
     "node_modules/cssstyle": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.3.tgz",
-      "integrity": "sha512-OytmFH+13/QXONJcC75QNdMtKpceNk3u8ThBjyyYjkEcy/ekBwR1mMAuNvi3gdBPW3N5TlCzQ0WZw8H0lN/bDw==",
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.6.tgz",
+      "integrity": "sha512-legscpSpgSAeGEe0TNcai97DKt9Vd9AsAdOL7Uoetb52Ar/8eJm3LIa39qpv8wWzLFlNG4vVvppQM+teaMPj3A==",
       "dependencies": {
-        "@asamuzakjp/css-color": "^4.0.3",
-        "@csstools/css-syntax-patches-for-csstree": "^1.0.14",
-        "css-tree": "^3.1.0"
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
       },
       "engines": {
         "node": ">=20"
@@ -1884,6 +1896,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/defu": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
+      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "dev": true
     },
     "node_modules/dequal": {
       "version": "2.0.3",
@@ -2015,9 +2033,9 @@
       "dev": true
     },
     "node_modules/esbuild": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
-      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
+      "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -2027,32 +2045,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.12",
-        "@esbuild/android-arm": "0.25.12",
-        "@esbuild/android-arm64": "0.25.12",
-        "@esbuild/android-x64": "0.25.12",
-        "@esbuild/darwin-arm64": "0.25.12",
-        "@esbuild/darwin-x64": "0.25.12",
-        "@esbuild/freebsd-arm64": "0.25.12",
-        "@esbuild/freebsd-x64": "0.25.12",
-        "@esbuild/linux-arm": "0.25.12",
-        "@esbuild/linux-arm64": "0.25.12",
-        "@esbuild/linux-ia32": "0.25.12",
-        "@esbuild/linux-loong64": "0.25.12",
-        "@esbuild/linux-mips64el": "0.25.12",
-        "@esbuild/linux-ppc64": "0.25.12",
-        "@esbuild/linux-riscv64": "0.25.12",
-        "@esbuild/linux-s390x": "0.25.12",
-        "@esbuild/linux-x64": "0.25.12",
-        "@esbuild/netbsd-arm64": "0.25.12",
-        "@esbuild/netbsd-x64": "0.25.12",
-        "@esbuild/openbsd-arm64": "0.25.12",
-        "@esbuild/openbsd-x64": "0.25.12",
-        "@esbuild/openharmony-arm64": "0.25.12",
-        "@esbuild/sunos-x64": "0.25.12",
-        "@esbuild/win32-arm64": "0.25.12",
-        "@esbuild/win32-ia32": "0.25.12",
-        "@esbuild/win32-x64": "0.25.12"
+        "@esbuild/aix-ppc64": "0.27.2",
+        "@esbuild/android-arm": "0.27.2",
+        "@esbuild/android-arm64": "0.27.2",
+        "@esbuild/android-x64": "0.27.2",
+        "@esbuild/darwin-arm64": "0.27.2",
+        "@esbuild/darwin-x64": "0.27.2",
+        "@esbuild/freebsd-arm64": "0.27.2",
+        "@esbuild/freebsd-x64": "0.27.2",
+        "@esbuild/linux-arm": "0.27.2",
+        "@esbuild/linux-arm64": "0.27.2",
+        "@esbuild/linux-ia32": "0.27.2",
+        "@esbuild/linux-loong64": "0.27.2",
+        "@esbuild/linux-mips64el": "0.27.2",
+        "@esbuild/linux-ppc64": "0.27.2",
+        "@esbuild/linux-riscv64": "0.27.2",
+        "@esbuild/linux-s390x": "0.27.2",
+        "@esbuild/linux-x64": "0.27.2",
+        "@esbuild/netbsd-arm64": "0.27.2",
+        "@esbuild/netbsd-x64": "0.27.2",
+        "@esbuild/openbsd-arm64": "0.27.2",
+        "@esbuild/openbsd-x64": "0.27.2",
+        "@esbuild/openharmony-arm64": "0.27.2",
+        "@esbuild/sunos-x64": "0.27.2",
+        "@esbuild/win32-arm64": "0.27.2",
+        "@esbuild/win32-ia32": "0.27.2",
+        "@esbuild/win32-x64": "0.27.2"
       }
     },
     "node_modules/estree-walker": {
@@ -2117,20 +2135,20 @@
       }
     },
     "node_modules/hookable": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
-      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.0.1.tgz",
+      "integrity": "sha512-uKGyY8BuzN/a5gvzvA+3FVWo0+wUjgtfSdnmjtrOVwQCZPHpHDH2WRO3VZSOeluYrHoDCiXFffZXs8Dj1ULWtw==",
       "dev": true
     },
     "node_modules/html-encoding-sniffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
-      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
       "dependencies": {
-        "whatwg-encoding": "^3.1.1"
+        "@exodus/bytes": "^1.6.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/htmlparser2": {
@@ -2198,9 +2216,9 @@
       }
     },
     "node_modules/import-without-cache": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/import-without-cache/-/import-without-cache-0.2.2.tgz",
-      "integrity": "sha512-4TTuRrZ0jBULXzac3EoX9ZviOs8Wn9iAbNhJEyLhTpAGF9eNmYSruaMMN/Tec/yqaO7H6yS2kALfQDJ5FxfatA==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/import-without-cache/-/import-without-cache-0.2.5.tgz",
+      "integrity": "sha512-B6Lc2s6yApwnD2/pMzFh/d5AVjdsDXjgkeJ766FmFuJELIGHNycKRj+l3A39yZPM4CchqNCB4RITEAYB1KUM6A==",
       "dev": true,
       "engines": {
         "node": ">=20.19.0"
@@ -2215,16 +2233,17 @@
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
     },
     "node_modules/jsdom": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.2.0.tgz",
-      "integrity": "sha512-454TI39PeRDW1LgpyLPyURtB4Zx1tklSr6+OFOipsxGUH1WMTvk6C65JQdrj455+DP2uJ1+veBEHTGFKWVLFoA==",
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
+      "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "dependencies": {
-        "@acemir/cssom": "^0.9.23",
-        "@asamuzakjp/dom-selector": "^6.7.4",
-        "cssstyle": "^5.3.3",
+        "@acemir/cssom": "^0.9.28",
+        "@asamuzakjp/dom-selector": "^6.7.6",
+        "@exodus/bytes": "^1.6.0",
+        "cssstyle": "^5.3.4",
         "data-urls": "^6.0.0",
         "decimal.js": "^10.6.0",
-        "html-encoding-sniffer": "^4.0.0",
+        "html-encoding-sniffer": "^6.0.0",
         "http-proxy-agent": "^7.0.2",
         "https-proxy-agent": "^7.0.6",
         "is-potential-custom-element-name": "^1.0.1",
@@ -2234,7 +2253,6 @@
         "tough-cookie": "^6.0.0",
         "w3c-xmlserializer": "^5.0.0",
         "webidl-conversions": "^8.0.0",
-        "whatwg-encoding": "^3.1.1",
         "whatwg-mimetype": "^4.0.0",
         "whatwg-url": "^15.1.0",
         "ws": "^8.18.3",
@@ -2947,13 +2965,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-beta.53",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-beta.53.tgz",
-      "integrity": "sha512-Qd9c2p0XKZdgT5AYd+KgAMggJ8ZmCs3JnS9PTMWkyUfteKlfmKtxJbWTHkVakxwXs1Ub7jrRYVeFeF7N0sQxyw==",
+      "version": "1.0.0-beta.57",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-beta.57.tgz",
+      "integrity": "sha512-lMMxcNN71GMsSko8RyeTaFoATHkCh4IWU7pYF73ziMYjhHZWfVesC6GQ+iaJCvZmVjvgSks9Ks1aaqEkBd8udg==",
       "dev": true,
       "dependencies": {
-        "@oxc-project/types": "=0.101.0",
-        "@rolldown/pluginutils": "1.0.0-beta.53"
+        "@oxc-project/types": "=0.103.0",
+        "@rolldown/pluginutils": "1.0.0-beta.57"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -2962,35 +2980,34 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-beta.53",
-        "@rolldown/binding-darwin-arm64": "1.0.0-beta.53",
-        "@rolldown/binding-darwin-x64": "1.0.0-beta.53",
-        "@rolldown/binding-freebsd-x64": "1.0.0-beta.53",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-beta.53",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-beta.53",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-beta.53",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-beta.53",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-beta.53",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-beta.53",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-beta.53",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-beta.53",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-beta.53"
+        "@rolldown/binding-android-arm64": "1.0.0-beta.57",
+        "@rolldown/binding-darwin-arm64": "1.0.0-beta.57",
+        "@rolldown/binding-darwin-x64": "1.0.0-beta.57",
+        "@rolldown/binding-freebsd-x64": "1.0.0-beta.57",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-beta.57",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-beta.57",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-beta.57",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-beta.57",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-beta.57",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-beta.57",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-beta.57",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-beta.57",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-beta.57"
       }
     },
     "node_modules/rolldown-plugin-dts": {
-      "version": "0.18.3",
-      "resolved": "https://registry.npmjs.org/rolldown-plugin-dts/-/rolldown-plugin-dts-0.18.3.tgz",
-      "integrity": "sha512-rd1LZ0Awwfyn89UndUF/HoFF4oH9a5j+2ZeuKSJYM80vmeN/p0gslYMnHTQHBEXPhUlvAlqGA3tVgXB/1qFNDg==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/rolldown-plugin-dts/-/rolldown-plugin-dts-0.20.0.tgz",
+      "integrity": "sha512-cLAY1kN2ilTYMfZcFlGWbXnu6Nb+8uwUBsi+Mjbh4uIx7IN8uMOmJ7RxrrRgPsO4H7eSz3E+JwGoL1gyugiyUA==",
       "dev": true,
       "dependencies": {
         "@babel/generator": "^7.28.5",
         "@babel/parser": "^7.28.5",
         "@babel/types": "^7.28.5",
         "ast-kit": "^2.2.0",
-        "birpc": "^3.0.0",
+        "birpc": "^4.0.0",
         "dts-resolver": "^2.1.3",
         "get-tsconfig": "^4.13.0",
-        "magic-string": "^0.30.21",
         "obug": "^2.1.1"
       },
       "engines": {
@@ -3002,9 +3019,9 @@
       "peerDependencies": {
         "@ts-macro/tsc": "^0.3.6",
         "@typescript/native-preview": ">=7.0.0-dev.20250601.1",
-        "rolldown": "^1.0.0-beta.51",
+        "rolldown": "^1.0.0-beta.57",
         "typescript": "^5.0.0",
-        "vue-tsc": "~3.1.0"
+        "vue-tsc": "~3.2.0"
       },
       "peerDependenciesMeta": {
         "@ts-macro/tsc": {
@@ -3022,9 +3039,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.3.tgz",
-      "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.54.0.tgz",
+      "integrity": "sha512-3nk8Y3a9Ea8szgKhinMlGMhGMw89mqule3KWczxhIzqudyHdCIOHw8WJlj/r329fACjKLEh13ZSk7oE22kyeIw==",
       "dev": true,
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -3037,28 +3054,28 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.53.3",
-        "@rollup/rollup-android-arm64": "4.53.3",
-        "@rollup/rollup-darwin-arm64": "4.53.3",
-        "@rollup/rollup-darwin-x64": "4.53.3",
-        "@rollup/rollup-freebsd-arm64": "4.53.3",
-        "@rollup/rollup-freebsd-x64": "4.53.3",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.53.3",
-        "@rollup/rollup-linux-arm-musleabihf": "4.53.3",
-        "@rollup/rollup-linux-arm64-gnu": "4.53.3",
-        "@rollup/rollup-linux-arm64-musl": "4.53.3",
-        "@rollup/rollup-linux-loong64-gnu": "4.53.3",
-        "@rollup/rollup-linux-ppc64-gnu": "4.53.3",
-        "@rollup/rollup-linux-riscv64-gnu": "4.53.3",
-        "@rollup/rollup-linux-riscv64-musl": "4.53.3",
-        "@rollup/rollup-linux-s390x-gnu": "4.53.3",
-        "@rollup/rollup-linux-x64-gnu": "4.53.3",
-        "@rollup/rollup-linux-x64-musl": "4.53.3",
-        "@rollup/rollup-openharmony-arm64": "4.53.3",
-        "@rollup/rollup-win32-arm64-msvc": "4.53.3",
-        "@rollup/rollup-win32-ia32-msvc": "4.53.3",
-        "@rollup/rollup-win32-x64-gnu": "4.53.3",
-        "@rollup/rollup-win32-x64-msvc": "4.53.3",
+        "@rollup/rollup-android-arm-eabi": "4.54.0",
+        "@rollup/rollup-android-arm64": "4.54.0",
+        "@rollup/rollup-darwin-arm64": "4.54.0",
+        "@rollup/rollup-darwin-x64": "4.54.0",
+        "@rollup/rollup-freebsd-arm64": "4.54.0",
+        "@rollup/rollup-freebsd-x64": "4.54.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.54.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.54.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.54.0",
+        "@rollup/rollup-linux-arm64-musl": "4.54.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.54.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.54.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.54.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.54.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.54.0",
+        "@rollup/rollup-linux-x64-gnu": "4.54.0",
+        "@rollup/rollup-linux-x64-musl": "4.54.0",
+        "@rollup/rollup-openharmony-arm64": "4.54.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.54.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.54.0",
+        "@rollup/rollup-win32-x64-gnu": "4.54.0",
+        "@rollup/rollup-win32-x64-msvc": "4.54.0",
         "fsevents": "~2.3.2"
       }
     },
@@ -3209,25 +3226,27 @@
       }
     },
     "node_modules/tsdown": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/tsdown/-/tsdown-0.17.0.tgz",
-      "integrity": "sha512-NPZRrlC51X9Bb55ZTDwrWges8Dm1niCvNA5AYw7aix6pfnDnB4WR0neG5RPq75xIodg3hqlQUzzyrX7n4dmnJg==",
+      "version": "0.18.4",
+      "resolved": "https://registry.npmjs.org/tsdown/-/tsdown-0.18.4.tgz",
+      "integrity": "sha512-J/tRS6hsZTkvqmt4+xdELUCkQYDuUCXgBv0fw3ImV09WPGbEKfsPD65E+WUjSu3E7Z6tji9XZ1iWs8rbGqB/ZA==",
       "dev": true,
       "dependencies": {
         "ansis": "^4.2.0",
         "cac": "^6.7.14",
+        "defu": "^6.1.4",
         "empathic": "^2.0.0",
-        "hookable": "^5.5.3",
-        "import-without-cache": "^0.2.2",
+        "hookable": "^6.0.1",
+        "import-without-cache": "^0.2.5",
         "obug": "^2.1.1",
-        "rolldown": "1.0.0-beta.53",
-        "rolldown-plugin-dts": "^0.18.2",
+        "picomatch": "^4.0.3",
+        "rolldown": "1.0.0-beta.57",
+        "rolldown-plugin-dts": "^0.20.0",
         "semver": "^7.7.3",
         "tinyexec": "^1.0.2",
         "tinyglobby": "^0.2.15",
         "tree-kill": "^1.2.2",
-        "unconfig-core": "^7.4.1",
-        "unrun": "^0.2.16"
+        "unconfig-core": "^7.4.2",
+        "unrun": "^0.2.21"
       },
       "bin": {
         "tsdown": "dist/run.mjs"
@@ -3240,7 +3259,7 @@
       },
       "peerDependencies": {
         "@arethetypeswrong/core": "^0.18.1",
-        "@vitejs/devtools": "^0.0.0-alpha.18",
+        "@vitejs/devtools": "*",
         "publint": "^0.3.0",
         "typescript": "^5.0.0",
         "unplugin-lightningcss": "^0.4.0",
@@ -3374,13 +3393,12 @@
       }
     },
     "node_modules/unrun": {
-      "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/unrun/-/unrun-0.2.17.tgz",
-      "integrity": "sha512-mumOyjZp1K1bsa1QwfRPw7+9TxyVHSgx6LHB2dBWI4m1hGDG9b2TK3fS3H8vCl/Gl9YTSxhZ9XuLbWv3QF8GEA==",
+      "version": "0.2.21",
+      "resolved": "https://registry.npmjs.org/unrun/-/unrun-0.2.21.tgz",
+      "integrity": "sha512-VuwI4YKtwBpDvM7hCEop2Im/ezS82dliqJpkh9pvS6ve8HcUsBDvESHxMmUfImXR03GkmfdDynyrh/pUJnlguw==",
       "dev": true,
       "dependencies": {
-        "@oxc-project/runtime": "^0.101.0",
-        "rolldown": "1.0.0-beta.53"
+        "rolldown": "1.0.0-beta.57"
       },
       "bin": {
         "unrun": "dist/cli.mjs"
@@ -3401,12 +3419,12 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.2.6",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.6.tgz",
-      "integrity": "sha512-tI2l/nFHC5rLh7+5+o7QjKjSR04ivXDF4jcgV0f/bTQ+OJiITy5S6gaynVsEM+7RqzufMnVbIon6Sr5x1SDYaQ==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.0.tgz",
+      "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
       "dev": true,
       "dependencies": {
-        "esbuild": "^0.25.0",
+        "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",
@@ -3475,18 +3493,18 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.15.tgz",
-      "integrity": "sha512-n1RxDp8UJm6N0IbJLQo+yzLZ2sQCDyl1o0LeugbPWf8+8Fttp29GghsQBjYJVmWq3gBFfe9Hs1spR44vovn2wA==",
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.16.tgz",
+      "integrity": "sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==",
       "dev": true,
       "dependencies": {
-        "@vitest/expect": "4.0.15",
-        "@vitest/mocker": "4.0.15",
-        "@vitest/pretty-format": "4.0.15",
-        "@vitest/runner": "4.0.15",
-        "@vitest/snapshot": "4.0.15",
-        "@vitest/spy": "4.0.15",
-        "@vitest/utils": "4.0.15",
+        "@vitest/expect": "4.0.16",
+        "@vitest/mocker": "4.0.16",
+        "@vitest/pretty-format": "4.0.16",
+        "@vitest/runner": "4.0.16",
+        "@vitest/snapshot": "4.0.16",
+        "@vitest/spy": "4.0.16",
+        "@vitest/utils": "4.0.16",
         "es-module-lexer": "^1.7.0",
         "expect-type": "^1.2.2",
         "magic-string": "^0.30.21",
@@ -3514,10 +3532,10 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.0.15",
-        "@vitest/browser-preview": "4.0.15",
-        "@vitest/browser-webdriverio": "4.0.15",
-        "@vitest/ui": "4.0.15",
+        "@vitest/browser-playwright": "4.0.16",
+        "@vitest/browser-preview": "4.0.16",
+        "@vitest/browser-webdriverio": "4.0.16",
+        "@vitest/ui": "4.0.16",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -3651,9 +3669,9 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
     },
     "node_modules/zod": {
-      "version": "4.1.13",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.13.tgz",
-      "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.4.tgz",
+      "integrity": "sha512-Zw/uYiiyF6pUT1qmKbZziChgNPRu+ZRneAsMUDU6IwmXdWt5JwcUfy2bvLOCUtz5UniaN/Zx5aFttZYbYc7O/A==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scrapex",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scrapex",
-      "version": "1.0.0-alpha.1",
+      "version": "1.0.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrapex",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-beta.1",
   "description": "Modern web scraper with LLM-enhanced extraction, extensible pipeline, and pluggable parsers",
   "type": "module",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -63,22 +63,22 @@
   "dependencies": {
     "@mozilla/readability": "^0.6.0",
     "cheerio": "^1.1.2",
-    "jsdom": "^27.2.0",
+    "jsdom": "^27.4.0",
     "mdast-util-from-markdown": "^2.0.2",
     "mdast-util-to-string": "^4.0.0",
     "turndown": "^7.2.2",
     "unist-util-visit": "^5.0.0",
-    "zod": "^4.1.13"
+    "zod": "^4.3.4"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.3.8",
+    "@biomejs/biome": "^2.3.10",
     "@types/jsdom": "^27.0.0",
     "@types/mdast": "^4.0.4",
     "@types/node": "^22.10.0",
     "@types/turndown": "^5.0.6",
-    "tsdown": "^0.17.0",
+    "tsdown": "^0.18.4",
     "typescript": "^5.9.3",
-    "vitest": "^4.0.15"
+    "vitest": "^4.0.16"
   },
   "peerDependencies": {
     "@anthropic-ai/sdk": ">=0.30.0",

--- a/src/fetchers/fetch.ts
+++ b/src/fetchers/fetch.ts
@@ -67,10 +67,20 @@ export class NativeFetcher implements Fetcher {
       }
 
       const contentType = response.headers.get('content-type') || '';
-
-      // Ensure we're getting HTML
-      if (!contentType.includes('text/html') && !contentType.includes('application/xhtml')) {
-        throw new ScrapeError(`Unexpected content type: ${contentType}`, 'PARSE_ERROR');
+      
+      // Validate content type
+      if (options.allowedContentTypes) {
+        const isAllowed = options.allowedContentTypes.some(type => 
+          contentType.toLowerCase().includes(type.toLowerCase())
+        );
+        if (!isAllowed) {
+          throw new ScrapeError(`Unexpected content type: ${contentType}`, 'PARSE_ERROR');
+        }
+      } else {
+        // Default behavior: Ensure we're getting HTML
+        if (!contentType.includes('text/html') && !contentType.includes('application/xhtml')) {
+          throw new ScrapeError(`Unexpected content type: ${contentType}`, 'PARSE_ERROR');
+        }
       }
 
       const html = await response.text();

--- a/src/fetchers/types.ts
+++ b/src/fetchers/types.ts
@@ -25,6 +25,12 @@ export interface FetchOptions {
 
   /** Additional headers to send */
   headers?: Record<string, string>;
+
+  /**
+   * Allowed MIME types.
+   * Defaults to HTML/XHTML if undefined.
+   */
+  allowedContentTypes?: string[];
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,8 +50,11 @@ export {
   NativeFetcher,
   type RobotsCheckResult,
 } from './fetchers/index.js';
-// URL utilities
+// Parsers
+export { RSSParser } from './parsers/index.js';
+// Utilities (URL + Feed)
 export {
+  // URL utilities
   extractDomain,
   getPath,
   getProtocol,
@@ -60,4 +63,11 @@ export {
   matchesUrlPattern,
   normalizeUrl,
   resolveUrl,
+  // Feed utilities
+  fetchFeed,
+  discoverFeeds,
+  filterByDate,
+  feedToMarkdown,
+  feedToText,
+  paginateFeed,
 } from './utils/index.js';

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -15,6 +15,10 @@ export {
   MarkdownParser,
   parseByHeadings,
 } from './markdown.js';
+// RSS parser (pure parsing, no I/O)
+export { RSSParser } from './rss.js';
+export type { RSSParserOptions } from './rss.js';
+
 export type {
   CodeBlock,
   GitHubMeta,
@@ -23,4 +27,8 @@ export type {
   ParsedMarkdown,
   ParserResult,
   SourceParser,
+  FeedItem,
+  FeedEnclosure,
+  ParsedFeed,
+  FeedMeta,
 } from './types.js';

--- a/src/parsers/rss.ts
+++ b/src/parsers/rss.ts
@@ -1,0 +1,454 @@
+import * as cheerio from "cheerio";
+import type { Element } from "domhandler";
+import type {
+  FeedEnclosure,
+  FeedItem,
+  FeedMeta,
+  ParsedFeed,
+  ParserResult,
+  SourceParser,
+} from "./types.js";
+
+export interface RSSParserOptions {
+  /**
+   * Map of custom field names to CSS selectors or XML tag names.
+   * Useful for extracting podcast/media namespace fields.
+   * @example { duration: "itunes\:duration", rating: "media\:rating" }
+   */
+  customFields?: Record<string, string>;
+}
+
+/**
+ * RSS/Atom feed parser.
+ * Supports RSS 2.0, RSS 1.0 (RDF), and Atom 1.0 formats.
+ *
+ * @example
+ * ```ts
+ * import { RSSParser } from 'scrapex/parsers';
+ *
+ * const parser = new RSSParser();
+ * const result = parser.parse(feedXml, 'https://example.com/feed.xml');
+ *
+ * console.log(result.data.title);
+ * console.log(result.data.items);
+ * ```
+ */
+export class RSSParser implements SourceParser<ParsedFeed, FeedMeta> {
+  readonly name = "rss";
+  private customFields: Record<string, string>;
+
+  constructor(options?: RSSParserOptions) {
+    this.customFields = options?.customFields || {};
+  }
+
+  canParse(content: string): boolean {
+    const lower = content.toLowerCase();
+    return (
+      lower.includes("<rss") ||
+      lower.includes("<feed") ||
+      lower.includes("<rdf:rdf")
+    );
+  }
+
+  parse(content: string, url?: string): ParserResult<ParsedFeed, FeedMeta> {
+    // Cheerio's xml: true mode disables HTML entities and structure fixes,
+    // effectively preventing many XSS/injection vectors during parsing.
+    const $ = cheerio.load(content, { xml: true });
+
+    // Detect format and parse
+    if ($("feed").length > 0) {
+      return this.parseAtom($, url);
+    } else if ($("rdf\\:RDF, RDF").length > 0) {
+      return this.parseRSS1($, url);
+    } else {
+      return this.parseRSS2($, url);
+    }
+  }
+
+  private parseRSS2(
+    $: cheerio.CheerioAPI,
+    baseUrl?: string
+  ): ParserResult<ParsedFeed, FeedMeta> {
+    const channel = $("channel");
+    const feedLink = channel.find("> link").text();
+    const resolveBase = baseUrl || feedLink;
+
+    const items: FeedItem[] = $("item")
+      .map((_, el) => {
+        const $item = $(el);
+        const itemLink = $item.find("link").text();
+        const guid = $item.find("guid").text();
+        const pubDate = $item.find("pubDate").text();
+
+        // Resolve link with fallback to guid if it's a URL
+        const resolvedLink = this.resolveLink(itemLink, guid, resolveBase);
+
+        return {
+          id: guid || itemLink,
+          title: $item.find("title").text(),
+          link: resolvedLink,
+          description: this.parseText($item.find("description")),
+          content: this.parseContentEncoded($item.find("content\\:encoded")),
+          author:
+            $item.find("author").text() ||
+            $item.find("dc\\:creator").text() ||
+            undefined,
+          publishedAt: this.parseDate(pubDate),
+          rawPublishedAt: pubDate || undefined,
+          categories: this.parseCategories(
+            $item
+              .find("category")
+              .map((_, c) => $(c).text())
+              .get()
+          ),
+          enclosure: this.parseEnclosure($item.find("enclosure"), resolveBase),
+          customFields: this.extractCustomFields($item),
+        };
+      })
+      .get();
+
+    return {
+      data: {
+        format: "rss2",
+        title: channel.find("> title").text(),
+        description: channel.find("> description").text() || undefined,
+        link: this.resolveUrl(feedLink, resolveBase),
+        language: channel.find("> language").text() || undefined,
+        lastBuildDate: this.parseDate(channel.find("> lastBuildDate").text()),
+        copyright: channel.find("> copyright").text() || undefined,
+        items,
+        customFields: this.extractCustomFields(channel),
+      },
+      meta: {
+        generator: channel.find("> generator").text() || undefined,
+        ttl: this.parseNumber(channel.find("> ttl").text()),
+        image: this.parseImage(channel.find("> image"), resolveBase),
+        categories: this.parseCategories(
+          channel
+            .find("> category")
+            .map((_, c) => $(c).text())
+            .get()
+        ),
+      },
+    };
+  }
+
+  private parseAtom(
+    $: cheerio.CheerioAPI,
+    baseUrl?: string
+  ): ParserResult<ParsedFeed, FeedMeta> {
+    const feed = $("feed");
+    const feedLink =
+      feed.find('> link[rel="alternate"], > link:not([rel])').attr("href") ||
+      "";
+    const nextLink = feed.find('> link[rel="next"]').attr("href");
+    const resolveBase = baseUrl || feedLink;
+
+    const items: FeedItem[] = $("entry")
+      .map((_, el) => {
+        const $entry = $(el);
+        const entryLink =
+          $entry.find('link[rel="alternate"], link:not([rel])').attr("href") ||
+          "";
+        const entryId = $entry.find("id").text();
+        const published = $entry.find("published").text();
+        const updated = $entry.find("updated").text();
+
+        // Resolve link with fallback to id if it's a URL
+        const resolvedLink = this.resolveLink(entryLink, entryId, resolveBase);
+
+        return {
+          id: entryId,
+          title: $entry.find("title").text(),
+          link: resolvedLink,
+          description: this.parseText($entry.find("summary")),
+          content: this.parseText($entry.find("content")),
+          author: $entry.find("author name").text() || undefined,
+          publishedAt: this.parseDate(published),
+          rawPublishedAt: published || updated || undefined,
+          updatedAt: this.parseDate(updated),
+          categories: this.parseCategories(
+            $entry
+              .find("category")
+              .map((_, c) => $(c).attr("term"))
+              .get()
+          ),
+          customFields: this.extractCustomFields($entry),
+        };
+      })
+      .get();
+
+    return {
+      data: {
+        format: "atom",
+        title: feed.find("> title").text(),
+        description: feed.find("> subtitle").text() || undefined,
+        link: this.resolveUrl(feedLink, resolveBase),
+        next: nextLink ? this.resolveUrl(nextLink, resolveBase) : undefined,
+        language: feed.attr("xml:lang") || undefined,
+        lastBuildDate: this.parseDate(feed.find("> updated").text()),
+        copyright: feed.find("> rights").text() || undefined,
+        items,
+        customFields: this.extractCustomFields(feed),
+      },
+      meta: {
+        generator: feed.find("> generator").text() || undefined,
+        image: this.parseAtomImage(feed, resolveBase),
+        categories: this.parseCategories(
+          feed
+            .find("> category")
+            .map((_, c) => $(c).attr("term"))
+            .get()
+        ),
+      },
+    };
+  }
+
+  private parseRSS1(
+    $: cheerio.CheerioAPI,
+    baseUrl?: string
+  ): ParserResult<ParsedFeed, FeedMeta> {
+    const channel = $("channel");
+    const feedLink = channel.find("link").text();
+    const resolveBase = baseUrl || feedLink;
+
+    // RSS 1.0 items are siblings of channel, not children
+    const items: FeedItem[] = $("item")
+      .map((_, el) => {
+        const $item = $(el);
+        const itemLink = $item.find("link").text();
+        const rdfAbout = $item.attr("rdf:about") || "";
+        const dcDate = $item.find("dc\\:date").text();
+
+        // Resolve link with fallback to rdf:about
+        const resolvedLink = this.resolveLink(itemLink, rdfAbout, resolveBase);
+
+        // Extract dc:subject as categories (RSS 1.0 uses Dublin Core)
+        const dcSubjects = $item
+          .find("dc\\:subject")
+          .map((_, s) => $(s).text())
+          .get();
+
+        return {
+          id: rdfAbout || itemLink,
+          title: $item.find("title").text(),
+          link: resolvedLink,
+          description: this.parseText($item.find("description")),
+          content: this.parseContentEncoded($item.find("content\\:encoded")),
+          author: $item.find("dc\\:creator").text() || undefined,
+          publishedAt: this.parseDate(dcDate),
+          rawPublishedAt: dcDate || undefined,
+          categories: this.parseCategories(dcSubjects),
+          customFields: this.extractCustomFields($item),
+        };
+      })
+      .get();
+
+    // Parse RDF image element (sibling of channel)
+    const rdfImage = $("image");
+    const imageUrl =
+      rdfImage.find("url").text() || rdfImage.attr("rdf:resource");
+
+    return {
+      data: {
+        format: "rss1",
+        title: channel.find("title").text(),
+        description: channel.find("description").text() || undefined,
+        link: this.resolveUrl(feedLink, resolveBase),
+        language: channel.find("dc\\:language").text() || undefined,
+        lastBuildDate: this.parseDate(channel.find("dc\\:date").text()),
+        copyright: channel.find("dc\\:rights").text() || undefined,
+        items,
+        customFields: this.extractCustomFields(channel),
+      },
+      meta: {
+        generator:
+          channel.find("admin\\:generatorAgent").attr("rdf:resource") ||
+          undefined,
+        image: imageUrl
+          ? {
+              url: this.resolveUrl(imageUrl, resolveBase),
+              title: rdfImage.find("title").text() || undefined,
+              link:
+                this.resolveUrl(rdfImage.find("link").text(), resolveBase) ||
+                undefined,
+            }
+          : undefined,
+        categories: this.parseCategories(
+          channel
+            .find("dc\\:subject")
+            .map((_, s) => $(s).text())
+            .get()
+        ),
+      },
+    };
+  }
+
+  /**
+   * Extract custom fields from an element using configured selectors.
+   */
+  private extractCustomFields(
+    $el: cheerio.Cheerio<Element>
+  ): Record<string, string> | undefined {
+    if (Object.keys(this.customFields).length === 0) return undefined;
+
+    const fields: Record<string, string> = {};
+    for (const [key, selector] of Object.entries(this.customFields)) {
+      const value = $el.find(selector).text().trim();
+      if (value) {
+        fields[key] = value;
+      }
+    }
+
+    return Object.keys(fields).length > 0 ? fields : undefined;
+  }
+
+  /**
+   * Parse date string to ISO 8601 format.
+   * Returns undefined if parsing fails (never returns raw strings).
+   */
+  private parseDate(dateStr: string): string | undefined {
+    if (!dateStr?.trim()) return undefined;
+
+    try {
+      const date = new Date(dateStr);
+      // Check for invalid date
+      if (Number.isNaN(date.getTime())) {
+        return undefined;
+      }
+      return date.toISOString();
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
+   * Parse element text content, returning undefined if empty.
+   */
+  private parseText($el: cheerio.Cheerio<Element>): string | undefined {
+    const text = $el.text().trim();
+    return text || undefined;
+  }
+
+  /**
+   * Parse content:encoded, stripping HTML tags from CDATA content.
+   */
+  private parseContentEncoded($el: cheerio.Cheerio<Element>): string | undefined {
+    const raw = $el.text().trim();
+    if (!raw) return undefined;
+    return raw.replace(/<[^>]+>/g, "").trim() || undefined;
+  }
+
+  /**
+   * Parse categories/tags, filtering out empty strings.
+   */
+  private parseCategories(categories: (string | undefined)[]): string[] {
+    return categories
+      .map((c) => c?.trim())
+      .filter((c): c is string => !!c && c.length > 0);
+  }
+
+  /**
+   * Resolve a URL against a base URL.
+   * Only allows https scheme; all other schemes are rejected.
+   */
+  private resolveUrl(url: string, base?: string): string {
+    if (!url?.trim()) return "";
+
+    try {
+      const resolved = base ? new URL(url, base) : new URL(url);
+      return resolved.protocol === "https:" ? resolved.href : "";
+    } catch {
+      return "";
+    }
+  }
+
+  /**
+   * Resolve link with fallback to id/guid if primary link is empty and id is a URL.
+   * Only allows https scheme; all other schemes are rejected.
+   */
+  private resolveLink(
+    primaryLink: string,
+    fallbackId: string,
+    base?: string
+  ): string {
+    // Try primary link first
+    if (primaryLink?.trim()) {
+      return this.resolveUrl(primaryLink, base);
+    }
+
+    // Fallback to id if it looks like a URL
+    if (fallbackId?.trim()) {
+      try {
+        const resolvedId = new URL(fallbackId);
+        return resolvedId.protocol === "https:" ? resolvedId.href : "";
+      } catch {
+        // Not a valid URL, try resolving against base
+        return this.resolveUrl(fallbackId, base);
+      }
+    }
+
+    return "";
+  }
+
+  /**
+   * Parse enclosure element with URL resolution.
+   */
+  private parseEnclosure(
+    $enc: cheerio.Cheerio<Element>,
+    baseUrl?: string
+  ): FeedEnclosure | undefined {
+    const url = $enc.attr("url");
+    if (!url) return undefined;
+
+    return {
+      url: this.resolveUrl(url, baseUrl),
+      type: $enc.attr("type") || undefined,
+      length: this.parseNumber($enc.attr("length")),
+    };
+  }
+
+  /**
+   * Parse RSS image element with URL resolution.
+   */
+  private parseImage(
+    $img: cheerio.Cheerio<Element>,
+    baseUrl?: string
+  ): FeedMeta["image"] | undefined {
+    const url = $img.find("url").text();
+    if (!url) return undefined;
+
+    return {
+      url: this.resolveUrl(url, baseUrl),
+      title: $img.find("title").text() || undefined,
+      link: this.resolveUrl($img.find("link").text(), baseUrl) || undefined,
+    };
+  }
+
+  /**
+   * Parse Atom logo/icon element with URL resolution.
+   */
+  private parseAtomImage(
+    $feed: cheerio.Cheerio<Element>,
+    baseUrl?: string
+  ): FeedMeta["image"] | undefined {
+    const logo = $feed.find("> logo").text();
+    const icon = $feed.find("> icon").text();
+    const url = logo || icon;
+
+    if (!url) return undefined;
+
+    return {
+      url: this.resolveUrl(url, baseUrl),
+    };
+  }
+
+  /**
+   * Parse a string to number, returning undefined if invalid.
+   */
+  private parseNumber(value: string | undefined): number | undefined {
+    if (!value) return undefined;
+    const num = parseInt(value, 10);
+    return Number.isNaN(num) ? undefined : num;
+  }
+}

--- a/src/parsers/types.ts
+++ b/src/parsers/types.ts
@@ -28,6 +28,63 @@ export interface ParserResult<TData, TMeta = unknown> {
 }
 
 /**
+ * RSS/Atom feed item
+ */
+export interface FeedItem {
+  id: string;                    // guid (RSS) or id (Atom)
+  title: string;
+  link: string;                  // Resolved absolute URL (fallback to id if URL, else empty)
+  description?: string;          // summary/description (plain text)
+  content?: string;              // full content if available (plain text)
+  author?: string;
+  publishedAt?: string;          // ISO 8601 date or undefined (never raw strings)
+  rawPublishedAt?: string;       // Original date string for debugging/manual parsing
+  updatedAt?: string;            // ISO 8601 date or undefined (Atom)
+  categories: string[];          // Filtered, no empty strings
+  enclosure?: FeedEnclosure;     // podcast/media support
+  customFields?: Record<string, string>; // Extracted custom namespace fields
+}
+
+/**
+ * Media enclosure (podcasts, videos)
+ */
+export interface FeedEnclosure {
+  url: string;                   // Resolved absolute URL
+  type?: string;                 // MIME type
+  length?: number;               // bytes
+}
+
+/**
+ * Parsed feed structure
+ */
+export interface ParsedFeed {
+  format: 'rss2' | 'rss1' | 'atom';
+  title: string;
+  description?: string;
+  link: string;                  // Resolved absolute URL
+  next?: string;                 // Pagination link (RFC 5005 / Atom rel="next")
+  language?: string;
+  lastBuildDate?: string;        // ISO 8601 date or undefined
+  copyright?: string;            // Channel copyright/rights
+  items: FeedItem[];
+  customFields?: Record<string, string>; // Extracted custom namespace fields
+}
+
+/**
+ * Feed metadata
+ */
+export interface FeedMeta {
+  generator?: string;
+  ttl?: number;                  // refresh interval in minutes
+  image?: {
+    url: string;                 // Resolved absolute URL
+    title?: string;
+    link?: string;
+  };
+  categories?: string[];
+}
+
+/**
  * Markdown link extracted from content
  */
 export interface MarkdownLink {

--- a/src/utils/feed.ts
+++ b/src/utils/feed.ts
@@ -1,0 +1,192 @@
+import * as cheerio from "cheerio";
+import { defaultFetcher } from "../fetchers/fetch.js";
+import type { Fetcher } from "../fetchers/types.js";
+import { RSSParser, type RSSParserOptions } from "../parsers/rss.js";
+import type {
+  FeedItem,
+  FeedMeta,
+  ParsedFeed,
+  ParserResult,
+} from "../parsers/types.js";
+
+/**
+ * Fetch and parse an RSS/Atom feed from a URL.
+ * Uses scrapex's fetcher infrastructure for consistent behavior.
+ */
+export async function fetchFeed(
+  url: string,
+  options?: {
+    fetcher?: Fetcher;
+    timeout?: number;
+    userAgent?: string;
+    parserOptions?: RSSParserOptions;
+  }
+): Promise<ParserResult<ParsedFeed, FeedMeta>> {
+  const fetcher = options?.fetcher || defaultFetcher;
+
+  const result = await fetcher.fetch(url, {
+    timeout: options?.timeout,
+    userAgent: options?.userAgent,
+    allowedContentTypes: [
+      "application/rss+xml",
+      "application/atom+xml",
+      "application/rdf+xml",
+      "application/xml",
+      "text/xml",
+      "text/html", // Some feeds are served as HTML incorrectly
+    ],
+  });
+
+  const parser = new RSSParser(options?.parserOptions);
+  return parser.parse(result.html, url);
+}
+
+/**
+ * Detect RSS/Atom feed URLs from HTML.
+ * Supports RSS, Atom, and RDF feed types.
+ */
+export function discoverFeeds(html: string, baseUrl: string): string[] {
+  const $ = cheerio.load(html);
+  const feeds: string[] = [];
+  const seen = new Set<string>();
+
+  // Selector for all feed types
+  const selector = [
+    'link[type="application/rss+xml"]',
+    'link[type="application/atom+xml"]',
+    'link[type="application/rdf+xml"]',
+    'link[rel="alternate"][type*="xml"]',
+  ].join(", ");
+
+  $(selector).each((_, el) => {
+    const href = $(el).attr("href");
+    if (href) {
+      try {
+        const resolved = new URL(href, baseUrl).href;
+        if (!seen.has(resolved)) {
+          seen.add(resolved);
+          feeds.push(resolved);
+        }
+      } catch {
+        // Invalid URL, skip
+      }
+    }
+  });
+
+  return feeds;
+}
+
+/**
+ * Filter feed items by date range.
+ * Items without publishedAt are included by default.
+ */
+export function filterByDate(
+  items: FeedItem[],
+  options: { after?: Date; before?: Date; includeUndated?: boolean }
+): FeedItem[] {
+  const { after, before, includeUndated = true } = options;
+
+  return items.filter((item) => {
+    if (!item.publishedAt) {
+      return includeUndated;
+    }
+
+    const date = new Date(item.publishedAt);
+    if (after && date < after) return false;
+    if (before && date > before) return false;
+    return true;
+  });
+}
+
+/**
+ * Convert feed items to markdown for LLM consumption.
+ * Uses ISO 8601 date format for consistency across environments.
+ */
+export function feedToMarkdown(
+  feed: ParsedFeed,
+  options?: {
+    includeContent?: boolean;
+    maxItems?: number;
+  }
+): string {
+  const { includeContent = false, maxItems } = options || {};
+  const lines = [`# ${feed.title}`, ""];
+
+  if (feed.description) {
+    lines.push(feed.description, "");
+  }
+
+  const items = maxItems ? feed.items.slice(0, maxItems) : feed.items;
+
+  for (const item of items) {
+    lines.push(`## ${item.title}`);
+
+    if (item.publishedAt) {
+      // Use ISO date format for consistency (YYYY-MM-DD)
+      const date = item.publishedAt.split("T")[0];
+      lines.push(`*${date}*`);
+    }
+
+    lines.push("");
+
+    if (includeContent && item.content) {
+      lines.push(item.content);
+    } else if (item.description) {
+      lines.push(item.description);
+    }
+
+    lines.push(`[Read more](${item.link})`, "");
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Extract plain text from feed items for LLM processing.
+ * Concatenates title, description, and content.
+ */
+export function feedToText(
+  feed: ParsedFeed,
+  options?: {
+    maxItems?: number;
+    separator?: string;
+  }
+): string {
+  const { maxItems, separator = "\n\n---\n\n" } = options || {};
+  const items = maxItems ? feed.items.slice(0, maxItems) : feed.items;
+
+  return items
+    .map((item) => {
+      const parts = [item.title];
+      if (item.description) parts.push(item.description);
+      if (item.content) parts.push(item.content);
+      return parts.join("\n\n");
+    })
+    .join(separator);
+}
+
+/**
+ * Paginate through a feed using rel="next" links (RFC 5005).
+ * Returns an async generator that yields each page.
+ */
+export async function* paginateFeed(
+  url: string,
+  options?: {
+    fetcher?: Fetcher;
+    timeout?: number;
+    userAgent?: string;
+    maxPages?: number;
+  }
+): AsyncGenerator<ParsedFeed, void, unknown> {
+  const { maxPages = 10, ...fetchOptions } = options || {};
+  let currentUrl: string | undefined = url;
+  let pageCount = 0;
+
+  while (currentUrl && pageCount < maxPages) {
+    const result = await fetchFeed(currentUrl, fetchOptions);
+    yield result.data;
+
+    currentUrl = result.data.next;
+    pageCount++;
+  }
+}

--- a/src/utils/feed.ts
+++ b/src/utils/feed.ts
@@ -135,7 +135,11 @@ export function feedToMarkdown(
       lines.push(item.description);
     }
 
-    lines.push(`[Read more](${item.link})`, "");
+    if (item.link) {
+      lines.push(`[Read more](${item.link})`, "");
+    } else {
+      lines.push("");
+    }
   }
 
   return lines.join("\n");

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,13 @@
 export {
+  fetchFeed,
+  discoverFeeds,
+  filterByDate,
+  feedToMarkdown,
+  feedToText,
+  paginateFeed,
+} from './feed.js';
+
+export {
   extractDomain,
   getPath,
   getProtocol,

--- a/test/fixtures/atom-basic.xml
+++ b/test/fixtures/atom-basic.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Scrapex Atom Test</title>
+  <subtitle>Testing Atom parsing</subtitle>
+  <link href="https://example.com/atom" rel="self"/>
+  <link href="https://example.com/"/>
+  <link href="https://example.com/atom?page=2" rel="next"/>
+  <updated>2024-09-06T16:45:00Z</updated>
+  <author>
+    <name>Scrapex Team</name>
+  </author>
+  <id>urn:uuid:60a76c80-d399-11d9-b93C-0003939e0af6</id>
+
+  <entry>
+    <title>Atom Entry 1</title>
+    <link href="https://example.com/atom/1"/>
+    <id>urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a</id>
+    <updated>2024-09-06T16:45:00Z</updated>
+    <published>2024-09-06T16:45:00Z</published>
+    <summary>Atom summary</summary>
+    <content type="html">&lt;p&gt;Atom content&lt;/p&gt;</content>
+    <category term="Atom"/>
+    <category term="Testing"/>
+  </entry>
+</feed>

--- a/test/fixtures/atom-unsafe-links.xml
+++ b/test/fixtures/atom-unsafe-links.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Unsafe Link Feed</title>
+  <link rel="alternate" href="https://example.com/atom" />
+  <updated>2024-09-06T16:45:00Z</updated>
+  <entry>
+    <title>Bad Link 1</title>
+    <id>urn:uuid:11111111-1111-1111-1111-111111111111</id>
+    <link rel="alternate" href="javascript:alert('xss')" />
+    <summary>Entry with javascript link.</summary>
+  </entry>
+  <entry>
+    <title>Bad Link 2</title>
+    <id>urn:uuid:22222222-2222-2222-2222-222222222222</id>
+    <link rel="alternate" href="data:text/plain,hello" />
+    <summary>Entry with data link.</summary>
+  </entry>
+  <entry>
+    <title>Bad Link 3</title>
+    <id>urn:uuid:33333333-3333-3333-3333-333333333333</id>
+    <link rel="alternate" href="file:///etc/passwd" />
+    <summary>Entry with file link.</summary>
+  </entry>
+</feed>

--- a/test/fixtures/rss1-basic.xml
+++ b/test/fixtures/rss1-basic.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF 
+  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" 
+  xmlns="http://purl.org/rss/1.0/" 
+  xmlns:dc="http://purl.org/dc/elements/1.1/"
+>
+  <channel rdf:about="https://example.com/rss1.xml">
+    <title>Scrapex RSS 1.0 Test</title>
+    <link>https://example.com</link>
+    <description>Testing RSS 1.0 (RDF)</description>
+    <dc:date>2024-09-06T16:45:00Z</dc:date>
+    <dc:language>en</dc:language>
+    <items>
+      <rdf:Seq>
+        <rdf:li rdf:resource="https://example.com/item1"/>
+      </rdf:Seq>
+    </items>
+  </channel>
+  <item rdf:about="https://example.com/item1">
+    <title>RSS 1.0 Item</title>
+    <link>https://example.com/item1</link>
+    <description>RDF Description</description>
+    <dc:date>2024-09-06T16:45:00Z</dc:date>
+    <dc:creator>RDF Author</dc:creator>
+    <dc:subject>RDF Category</dc:subject>
+  </item>
+</rdf:RDF>

--- a/test/fixtures/rss2-basic.xml
+++ b/test/fixtures/rss2-basic.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:atom="http://www.w3.org/2005/Atom">
+<channel>
+  <title>Scrapex RSS 2.0 Test</title>
+  <link>https://example.com</link>
+  <description>Testing RSS 2.0 parsing</description>
+  <language>en-us</language>
+  <pubDate>Mon, 06 Sep 2024 16:45:00 +0000</pubDate>
+  <lastBuildDate>Mon, 06 Sep 2024 16:45:00 +0000</lastBuildDate>
+  <copyright>Copyright 2024</copyright>
+  <generator>Scrapex Generator</generator>
+  <item>
+    <title>RSS Item 1</title>
+    <link>https://example.com/item1</link>
+    <guid>https://example.com/item1</guid>
+    <pubDate>Mon, 06 Sep 2024 16:45:00 +0000</pubDate>
+    <description>This is a short description.</description>
+    <content:encoded><![CDATA[<p>This is the <strong>full</strong> content.</p>]]></content:encoded>
+    <author>John Doe</author>
+    <category>Tech</category>
+    <category>News</category>
+    <enclosure url="https://example.com/podcast.mp3" length="123456" type="audio/mpeg" />
+  </item>
+  <item>
+    <title>RSS Item 2</title>
+    <link>https://example.com/item2</link>
+    <guid isPermaLink="false">abc-123</guid>
+    <dc:creator>Jane Smith</dc:creator>
+  </item>
+</channel>
+</rss>

--- a/test/parsers/rss.test.ts
+++ b/test/parsers/rss.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { RSSParser } from '../../src/parsers/rss.js';
+import { 
+  fetchFeed, 
+  discoverFeeds, 
+  filterByDate, 
+  feedToMarkdown, 
+  feedToText, 
+  paginateFeed 
+} from '../../src/utils/feed.js';
+import { NativeFetcher } from '../../src/fetchers/fetch.js';
+import type { FetchResult } from '../../src/fetchers/types.js';
+
+// Read fixtures
+const fixturesDir = path.join(__dirname, '../fixtures');
+const rss2Content = fs.readFileSync(path.join(fixturesDir, 'rss2-basic.xml'), 'utf-8');
+const atomContent = fs.readFileSync(path.join(fixturesDir, 'atom-basic.xml'), 'utf-8');
+const atomUnsafeContent = fs.readFileSync(path.join(fixturesDir, 'atom-unsafe-links.xml'), 'utf-8');
+const rss1Content = fs.readFileSync(path.join(fixturesDir, 'rss1-basic.xml'), 'utf-8');
+
+describe('RSSParser', () => {
+  it('should parse RSS 2.0 feeds', () => {
+    const parser = new RSSParser();
+    expect(parser.canParse(rss2Content)).toBe(true);
+    
+    const result = parser.parse(rss2Content, 'https://example.com/feed.xml');
+    const { data } = result;
+
+    expect(data.format).toBe('rss2');
+    expect(data.title).toBe('Scrapex RSS 2.0 Test');
+    expect(data.link).toBe('https://example.com/'); // Normalized
+    expect(data.copyright).toBe('Copyright 2024');
+    expect(data.items).toHaveLength(2);
+
+    const item1 = data.items[0];
+    expect(item1.title).toBe('RSS Item 1');
+    expect(item1.link).toBe('https://example.com/item1');
+    expect(item1.description).toBe('This is a short description.');
+    expect(item1.content).toBe('This is the full content.');
+    expect(item1.author).toBe('John Doe');
+    expect(item1.categories).toEqual(['Tech', 'News']);
+    expect(item1.enclosure).toEqual({
+      url: 'https://example.com/podcast.mp3',
+      length: 123456,
+      type: 'audio/mpeg'
+    });
+
+    const item2 = data.items[1];
+    expect(item2.author).toBe('Jane Smith'); // dc:creator fallback
+    expect(item2.id).toBe('abc-123'); // guid
+  });
+
+  it('should parse Atom feeds', () => {
+    const parser = new RSSParser();
+    expect(parser.canParse(atomContent)).toBe(true);
+
+    const result = parser.parse(atomContent, 'https://example.com/atom');
+    const { data } = result;
+
+    expect(data.format).toBe('atom');
+    expect(data.title).toBe('Scrapex Atom Test');
+    expect(data.next).toBe('https://example.com/atom?page=2');
+    
+    const item = data.items[0];
+    expect(item.title).toBe('Atom Entry 1');
+    expect(item.id).toBe('urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a');
+    expect(item.publishedAt).toBe('2024-09-06T16:45:00.000Z');
+    expect(item.categories).toEqual(['Atom', 'Testing']);
+  });
+
+  it('should parse RSS 1.0 (RDF) feeds', () => {
+    const parser = new RSSParser();
+    expect(parser.canParse(rss1Content)).toBe(true);
+
+    const result = parser.parse(rss1Content);
+    const { data } = result;
+
+    expect(data.format).toBe('rss1');
+    expect(data.title).toBe('Scrapex RSS 1.0 Test');
+    
+    const item = data.items[0];
+    expect(item.title).toBe('RSS 1.0 Item');
+    expect(item.link).toBe('https://example.com/item1');
+    expect(item.categories).toEqual(['RDF Category']); // dc:subject
+  });
+
+  it('should drop non-https links', () => {
+    const parser = new RSSParser();
+    const result = parser.parse(atomUnsafeContent, 'https://example.com/atom');
+    const { data } = result;
+
+    expect(data.link).toBe('https://example.com/atom');
+    expect(data.items[0].link).toBe('');
+    expect(data.items[1].link).toBe('');
+  });
+  it('should extract custom fields', () => {
+    const customXml = `
+      <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+        <channel>
+          <title>Podcast</title>
+          <item>
+            <title>Episode 1</title>
+            <itunes:duration>10:00</itunes:duration>
+            <itunes:explicit>no</itunes:explicit>
+          </item>
+        </channel>
+      </rss>
+    `;
+
+    const parser = new RSSParser({
+      customFields: {
+        duration: 'itunes\\:duration',
+        explicit: 'itunes\\:explicit'
+      }
+    });
+
+    const result = parser.parse(customXml);
+    const item = result.data.items[0];
+
+    expect(item.customFields).toEqual({
+      duration: '10:00',
+      explicit: 'no'
+    });
+  });
+});
+
+describe('Feed Utilities', () => {
+  it('should discover feeds in HTML', () => {
+    const html = `
+      <html>
+        <head>
+          <link rel="alternate" type="application/rss+xml" href="/feed.xml" />
+          <link rel="alternate" type="application/atom+xml" href="https://example.com/atom" />
+        </head>
+      </html>
+    `;
+    const feeds = discoverFeeds(html, 'https://example.com');
+    expect(feeds).toEqual([
+      'https://example.com/feed.xml',
+      'https://example.com/atom'
+    ]);
+  });
+
+  it('should filter items by date', () => {
+    const items = [
+      { title: 'New', publishedAt: '2024-01-01T00:00:00Z', link: '', id: '', categories: [] },
+      { title: 'Old', publishedAt: '2023-01-01T00:00:00Z', link: '', id: '', categories: [] },
+      { title: 'Undated', link: '', id: '', categories: [] },
+    ];
+
+    const filtered = filterByDate(items, {
+      after: new Date('2023-12-31'),
+      includeUndated: false
+    });
+
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].title).toBe('New');
+
+    const withUndated = filterByDate(items, {
+      after: new Date('2023-12-31'),
+      includeUndated: true
+    });
+    expect(withUndated).toHaveLength(2);
+  });
+
+  it('should convert feed to markdown', () => {
+    const parser = new RSSParser();
+    const result = parser.parse(rss2Content);
+    const markdown = feedToMarkdown(result.data, { maxItems: 1 });
+
+    expect(markdown).toContain('# Scrapex RSS 2.0 Test');
+    expect(markdown).toContain('## RSS Item 1');
+    expect(markdown).toContain('*2024-09-06*');
+    expect(markdown).toContain('This is a short description.');
+    expect(markdown).not.toContain('RSS Item 2');
+  });
+
+  it('should not emit non-https links in markdown', () => {
+    const parser = new RSSParser();
+    const result = parser.parse(atomUnsafeContent, 'https://example.com/atom');
+    const markdown = feedToMarkdown(result.data);
+
+    expect(markdown).not.toContain('javascript:');
+    expect(markdown).not.toContain('data:');
+    expect(markdown).not.toContain('file:');
+  });
+
+  it('should fetch and parse feeds', async () => {
+    const mockFetcher = {
+      name: 'mock',
+      fetch: vi.fn().mockResolvedValue({
+        html: rss2Content,
+        finalUrl: 'https://example.com/feed.xml',
+        statusCode: 200,
+        contentType: 'application/rss+xml'
+      } as FetchResult)
+    };
+
+    const result = await fetchFeed('https://example.com/feed.xml', {
+      fetcher: mockFetcher
+    });
+
+    expect(mockFetcher.fetch).toHaveBeenCalledWith('https://example.com/feed.xml', expect.objectContaining({
+      allowedContentTypes: expect.arrayContaining(['application/rss+xml'])
+    }));
+    expect(result.data.title).toBe('Scrapex RSS 2.0 Test');
+  });
+
+  it('should paginate feeds', async () => {
+    const mockFetcher = {
+      name: 'mock',
+      fetch: vi.fn()
+        .mockResolvedValueOnce({
+          html: atomContent, // Has next link
+          finalUrl: 'https://example.com/atom',
+          statusCode: 200,
+          contentType: 'application/atom+xml'
+        } as FetchResult)
+        .mockResolvedValueOnce({
+          html: atomContent.replace('rel="next"', 'rel="prev"'), // No next link
+          finalUrl: 'https://example.com/atom?page=2',
+          statusCode: 200,
+          contentType: 'application/atom+xml'
+        } as FetchResult)
+    };
+
+    const pages = [];
+    for await (const page of paginateFeed('https://example.com/atom', { fetcher: mockFetcher })) {
+      pages.push(page);
+    }
+
+    expect(pages).toHaveLength(2);
+    expect(mockFetcher.fetch).toHaveBeenCalledTimes(2);
+    expect(mockFetcher.fetch).toHaveBeenNthCalledWith(2, 'https://example.com/atom?page=2', expect.any(Object));
+  });
+});

--- a/test/utils/url.test.ts
+++ b/test/utils/url.test.ts
@@ -109,6 +109,39 @@ describe('url utilities', () => {
         'https://other.com/path/to/resource'
       );
     });
+
+    it('should handle protocol-relative URLs with query strings', () => {
+      expect(resolveUrl('//cdn.example.com/script.js?v=1.0', baseUrl)).toBe(
+        'https://cdn.example.com/script.js?v=1.0'
+      );
+      expect(resolveUrl('//cdn.example.com/api?foo=bar&baz=qux', baseUrl)).toBe(
+        'https://cdn.example.com/api?foo=bar&baz=qux'
+      );
+    });
+
+    it('should handle protocol-relative URLs with fragments', () => {
+      expect(resolveUrl('//cdn.example.com/page#section', baseUrl)).toBe(
+        'https://cdn.example.com/page#section'
+      );
+      expect(resolveUrl('//cdn.example.com/docs#api-reference', baseUrl)).toBe(
+        'https://cdn.example.com/docs#api-reference'
+      );
+    });
+
+    it('should handle protocol-relative URLs with ports', () => {
+      expect(resolveUrl('//cdn.example.com:8080/resource', baseUrl)).toBe(
+        'https://cdn.example.com:8080/resource'
+      );
+      expect(resolveUrl('//localhost:3000/api', baseUrl)).toBe(
+        'https://localhost:3000/api'
+      );
+    });
+
+    it('should handle protocol-relative URLs with query strings, fragments, and ports combined', () => {
+      expect(resolveUrl('//cdn.example.com:8080/path?v=1#section', baseUrl)).toBe(
+        'https://cdn.example.com:8080/path?v=1#section'
+      );
+    });
   });
 
   describe('isExternalUrl', () => {

--- a/test/utils/url.test.ts
+++ b/test/utils/url.test.ts
@@ -93,6 +93,22 @@ describe('url utilities', () => {
       expect(resolveUrl(undefined, baseUrl)).toBeUndefined();
       expect(resolveUrl('', baseUrl)).toBeUndefined();
     });
+
+    it('should resolve protocol-relative URLs using base URL protocol', () => {
+      // Protocol-relative URLs inherit the protocol from the base URL
+      expect(resolveUrl('//cdn.example.com/script.js', 'https://example.com')).toBe(
+        'https://cdn.example.com/script.js'
+      );
+      expect(resolveUrl('//cdn.example.com/script.js', 'http://example.com')).toBe(
+        'http://cdn.example.com/script.js'
+      );
+    });
+
+    it('should handle protocol-relative URLs with paths', () => {
+      expect(resolveUrl('//other.com/path/to/resource', baseUrl)).toBe(
+        'https://other.com/path/to/resource'
+      );
+    });
   });
 
   describe('isExternalUrl', () => {


### PR DESCRIPTION
  RSS Parser:
  - Add RSSParser supporting RSS 2.0, RSS 1.0 (RDF), and Atom 1.0 formats
  - Add feed utilities: fetchFeed, discoverFeeds, filterByDate, feedToMarkdown, feedToText, paginateFeed
  - Enforce HTTPS-only URL resolution for security
  - Support custom namespace fields (iTunes, Media RSS)
  - Add allowedContentTypes to FetchOptions for non-HTML content

  Documentation:
  - Add RSS/Atom parsing guide with comprehensive examples
  - Update parsers API docs with RSSParser, ParsedFeed, FeedItem types
  - Add feed utilities to utilities API reference
  - Fix ScrapeError docs: remove non-existent url property, add isRetryable() and toJSON()
  - Fix error codes: FETCH_ERROR → FETCH_FAILED, add BLOCKED, NOT_FOUND, LLM_ERROR
  - Fix extractor priorities: ContentExtractor (50), LinksExtractor (30)
  - Add missing FaviconExtractor (priority 70) to docs
  - Align all code examples with actual API signatures

  Tests:
  - Add comprehensive tests for RSS 2.0, RSS 1.0, Atom parsing
  - Add tests for unsafe link filtering, custom fields, feed utilities

  BREAKING CHANGE: None - additive changes only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RSS/Atom feed support: parsing (RSS1/2, Atom), discovery, fetching, pagination, filtering, and export to Markdown/text; feed utilities exposed in public API
* **Improvements**
  * Richer scrape results and options (more metadata, LLM enhancement via llm+enhance, extractor behavior updates)
  * Fetcher accepts configurable allowed content types; improved error codes and retry behavior
  * Docs/README updated (installation tag changed to beta, added RSS/Atom guide)
* **Chores**
  * Release bumped to 1.0.0-beta.1

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->