### PR TITLE
feat(content): add first-class normalizeText pipeline

### DIFF
--- a/.github/releases/v1.0.0-beta.4.md
+++ b/.github/releases/v1.0.0-beta.4.md
@@ -1,0 +1,91 @@
+# scrapex v1.0.0-beta.4
+
+First-class content normalization for embedding-ready and LLM-optimized text output.
+
+## Highlights
+
+- New `normalize` option in `scrape()` produces clean, boilerplate-free text directly in `ScrapedData`.
+- Block-based content classification with customizable classifiers for filtering navigation, footers, and promotional content.
+- Embeddings pipeline now prefers `normalizedText` when available for higher quality vector representations.
+
+## New Features
+
+### Content Normalization (`normalize` option)
+
+```ts
+const result = await scrape(url, {
+  normalize: {
+    mode: 'full',           // or 'summary' for score-ranked blocks
+    removeBoilerplate: true, // filter nav, footer, promos
+    maxChars: 5000,          // truncate at sentence boundary
+  },
+});
+
+console.log(result.normalizedText);       // Clean text ready for embedding
+console.log(result.normalizationMeta);    // Char count, token estimate, hash
+```
+
+### Standalone Normalization
+
+```ts
+import { parseBlocks, normalizeText, combineClassifiers, defaultBlockClassifier } from 'scrapex';
+
+const $ = load(html);
+const blocks = parseBlocks($);
+const result = await normalizeText(blocks, { mode: 'full' });
+```
+
+### Custom Classifiers
+
+```ts
+const myClassifier = combineClassifiers(
+  defaultBlockClassifier,
+  (block) => {
+    if (block.text.includes('About the Author')) {
+      return { accept: false, label: 'author-bio' };
+    }
+    return { accept: true };
+  }
+);
+
+const result = await scrape(url, {
+  normalize: { blockClassifier: myClassifier },
+});
+```
+
+## New Types
+
+- `ContentBlock` - Classified content block with type, text, and context
+- `BlockType` - paragraph, heading, list, quote, table, code, media, nav, footer, promo, legal
+- `ClassifierResult` - accept/reject with optional score and label
+- `ContentBlockClassifier` - sync or async classifier function
+- `NormalizeOptions` - full configuration for normalization
+- `NormalizationMeta` - charCount, tokenEstimate, hash, blocksTotal/Accepted, truncated
+
+## Security
+
+- ReDoS prevention via input limiting (1000 char slice for regex matching)
+- `maxBlocks` enforcement (default 2000) prevents unbounded DOM traversal
+- HTML content only included when `includeHtml: true` is explicitly set
+- SHA-256 content hashing (128-bit via 32 hex chars) for deduplication
+
+## Documentation
+
+- New normalize-text design document with full API reference
+- Updated scrape, embeddings, and types documentation
+- New example: `examples/22-normalize-text.ts`
+
+## Installation
+
+```bash
+npm install scrapex@beta
+```
+
+## Notes
+
+- Requires **Node.js 20+**.
+- `normalizedText` is optional and does not affect existing `content`/`textContent` fields.
+
+---
+
+**Full Changelog**: [v1.0.0-beta.3...v1.0.0-beta.4](https://github.com/developer-rakeshpaul/scrapex/compare/v1.0.0-beta.3...v1.0.0-beta.4)

--- a/docs/src/content/docs/api/embeddings.mdx
+++ b/docs/src/content/docs/api/embeddings.mdx
@@ -412,7 +412,7 @@ Main configuration for embedding generation.
 interface EmbeddingOptions {
   provider: EmbeddingProviderConfig;
   model?: string;
-  preferNormalized?: boolean;
+  preferNormalized?: boolean; // Default: true. Use normalizedText instead of textContent when available.
   input?: EmbeddingInputConfig;
   chunking?: ChunkingConfig;
   output?: OutputConfig;

--- a/docs/src/content/docs/api/embeddings.mdx
+++ b/docs/src/content/docs/api/embeddings.mdx
@@ -412,6 +412,7 @@ Main configuration for embedding generation.
 interface EmbeddingOptions {
   provider: EmbeddingProviderConfig;
   model?: string;
+  preferNormalized?: boolean;
   input?: EmbeddingInputConfig;
   chunking?: ChunkingConfig;
   output?: OutputConfig;

--- a/docs/src/content/docs/api/scrape.mdx
+++ b/docs/src/content/docs/api/scrape.mdx
@@ -39,6 +39,7 @@ The URL to scrape. Must be a valid HTTP or HTTPS URL.
 | `enhance` | `EnhancementType[]` | `undefined` | LLM enhancement types |
 | `extract` | `ExtractionSchema` | `undefined` | LLM structured extraction schema |
 | `embeddings` | `EmbeddingOptions` | `undefined` | Generate vector embeddings |
+| `normalize` | `NormalizeOptions` | `undefined` | Normalize content into clean text |
 
 ## Returns
 
@@ -79,6 +80,11 @@ interface ScrapedData {
 
   // Embedding result (when embeddings option is provided)
   embeddings?: EmbeddingResult;
+
+  // Normalized text output (when normalize option is provided)
+  normalizedText?: string;
+  normalizationMeta?: NormalizationMeta;
+  normalizedBlocks?: ContentBlock[];
 }
 ```
 
@@ -142,6 +148,22 @@ const result = await scrape('https://example.com', {
 if (result.embeddings?.status === 'success') {
   console.log(result.embeddings.vector); // [0.023, -0.041, ...]
 }
+```
+
+### With Normalization
+
+```typescript
+import { scrape } from 'scrapex';
+
+const result = await scrape('https://example.com/article', {
+  normalize: {
+    mode: 'full',
+    removeBoilerplate: true,
+  },
+});
+
+console.log(result.normalizedText);
+console.log(result.normalizationMeta);
 ```
 
 ### With Custom Extractors

--- a/docs/src/content/docs/api/types.mdx
+++ b/docs/src/content/docs/api/types.mdx
@@ -56,6 +56,11 @@ interface ScrapedData {
   // Embedding result
   embeddings?: EmbeddingResult;
 
+  // Normalized text
+  normalizedText?: string;
+  normalizationMeta?: NormalizationMeta;
+  normalizedBlocks?: ContentBlock[];
+
   // Custom extractor data
   custom?: Record<string, unknown>;
 
@@ -93,6 +98,9 @@ interface ScrapeOptions {
 
   // Embeddings
   embeddings?: EmbeddingOptions;
+
+  // Normalization
+  normalize?: NormalizeOptions;
 }
 ```
 
@@ -135,6 +143,88 @@ interface ExtractedLink {
   url: string;
   text: string;
   isExternal: boolean;
+}
+```
+
+### NormalizeOptions
+
+Options for `scrape()` normalization.
+
+```typescript
+interface NormalizeOptions {
+  mode?: 'summary' | 'full';
+  maxChars?: number;
+  minChars?: number;
+  maxBlocks?: number;
+  truncate?: 'sentence' | 'word' | 'char';
+  dropSelectors?: string[];
+  removeBoilerplate?: boolean;
+  decodeEntities?: boolean;
+  normalizeUnicode?: boolean;
+  preserveLineBreaks?: boolean;
+  stripLinks?: boolean;
+  includeHtml?: boolean;
+  languageHint?: string;
+  blockClassifier?: ContentBlockClassifier;
+  debug?: boolean;
+}
+```
+
+### ContentBlock
+
+Classified content block used by normalization.
+
+```typescript
+interface ContentBlock {
+  type: BlockType;
+  text: string;
+  level?: 1 | 2 | 3 | 4 | 5 | 6;
+  html?: string;
+  attrs?: Record<string, string>;
+  context?: {
+    parentTags?: string[];
+    depth?: number;
+  };
+}
+```
+
+### ContentBlockClassifier
+
+```typescript
+type ContentBlockClassifier = (
+  block: ContentBlock,
+  context: ClassifierContext
+) => ClassifierResult | Promise<ClassifierResult>;
+```
+
+### ClassifierContext
+
+```typescript
+interface ClassifierContext {
+  index: number;
+  totalBlocks: number;
+  url?: string;
+  parentTags?: string[];
+  depth?: number;
+}
+```
+
+### NormalizationMeta
+
+Metadata returned when normalization is enabled.
+
+```typescript
+interface NormalizationMeta {
+  charCount: number;
+  tokenEstimate: number;
+  language: string;
+  boilerplateRemoved: boolean;
+  classifierUsed: boolean;
+  hash: string;
+  extractionTimeMs: number;
+  blocksTotal: number;
+  blocksAccepted: number;
+  truncated: boolean;
 }
 ```
 

--- a/docs/src/content/docs/guides/basic-scraping.mdx
+++ b/docs/src/content/docs/guides/basic-scraping.mdx
@@ -83,6 +83,8 @@ console.log(result.normalizedText);
 console.log(result.normalizationMeta);
 ```
 
+Note: For large pages, consider using `dropSelectors` to remove heavy DOM regions (nav, footer, ads, or SVGs) to improve normalization performance.
+
 ## Content Types
 
 scrapex automatically classifies content:

--- a/docs/src/content/docs/guides/basic-scraping.mdx
+++ b/docs/src/content/docs/guides/basic-scraping.mdx
@@ -67,6 +67,22 @@ const result = await scrape(url, {
 });
 ```
 
+### Normalization
+
+Generate clean, boilerplate-free text:
+
+```typescript
+const result = await scrape(url, {
+  normalize: {
+    mode: 'full',
+    removeBoilerplate: true,
+  },
+});
+
+console.log(result.normalizedText);
+console.log(result.normalizationMeta);
+```
+
 ## Content Types
 
 scrapex automatically classifies content:

--- a/docs/src/content/docs/guides/embeddings.mdx
+++ b/docs/src/content/docs/guides/embeddings.mdx
@@ -159,6 +159,18 @@ const result = await scrape(url, {
 });
 ```
 
+By default, embeddings prefer `normalizedText` when available (generated via `scrape({ normalize: ... })`). Disable this if you want raw `textContent` instead:
+
+```typescript
+const result = await scrape(url, {
+  normalize: { mode: 'full', removeBoilerplate: true },
+  embeddings: {
+    provider: providerConfig,
+    preferNormalized: false,
+  },
+});
+```
+
 ## Chunking Long Content
 
 For long documents, content is automatically chunked with overlap:

--- a/examples/22-normalize-text.ts
+++ b/examples/22-normalize-text.ts
@@ -1,0 +1,33 @@
+/**
+ * Normalize text during scraping.
+ *
+ * Demonstrates boilerplate removal and normalized output.
+ */
+import { scrapeHtml } from '../src/index.js';
+
+const html = `
+  <html>
+    <body>
+      <nav>Home About Subscribe</nav>
+      <main>
+        <h1>Normalization Demo</h1>
+        <p>This is the first paragraph.</p>
+        <p>This is the second paragraph with <a href="/more">a link</a>.</p>
+      </main>
+      <footer>All rights reserved</footer>
+    </body>
+  </html>
+`;
+
+const result = await scrapeHtml(html, 'https://example.com/demo', {
+  normalize: {
+    mode: 'full',
+    removeBoilerplate: true,
+    stripLinks: true,
+    debug: true,
+  },
+});
+
+console.log('Normalized text:\n', result.normalizedText);
+console.log('Normalization meta:', result.normalizationMeta);
+console.log('Blocks:', result.normalizedBlocks?.length);

--- a/examples/README.md
+++ b/examples/README.md
@@ -67,6 +67,7 @@ OLLAMA_EMBEDDING_MODEL=nomic-embed-text npx tsx examples/21-embeddings.ts
 | [02-scrape-options.ts](./02-scrape-options.ts) | All configuration options - timeout, userAgent, etc. |
 | [03-scrape-html.ts](./03-scrape-html.ts) | Scrape from HTML string (pre-fetched content) |
 | [04-custom-extractors.ts](./04-custom-extractors.ts) | Build custom extractors for domain-specific data |
+| [22-normalize-text.ts](./22-normalize-text.ts) | Normalize text with boilerplate removal and metadata |
 
 ### LLM Integration
 
@@ -106,6 +107,7 @@ OLLAMA_EMBEDDING_MODEL=nomic-embed-text npx tsx examples/21-embeddings.ts
 | [19-extractor-pipeline-debug.ts](./19-extractor-pipeline-debug.ts) | Debug extractor ordering, dependencies, and failure handling |
 | [20-rss-parsing.ts](./20-rss-parsing.ts) | Parse RSS/Atom feeds and convert to markdown |
 | [21-embeddings.ts](./21-embeddings.ts) | Generate embeddings from text or scraped content |
+| [22-normalize-text.ts](./22-normalize-text.ts) | Normalize text with boilerplate removal and metadata |
 
 ## Practice Sites
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -67,7 +67,6 @@ OLLAMA_EMBEDDING_MODEL=nomic-embed-text npx tsx examples/21-embeddings.ts
 | [02-scrape-options.ts](./02-scrape-options.ts) | All configuration options - timeout, userAgent, etc. |
 | [03-scrape-html.ts](./03-scrape-html.ts) | Scrape from HTML string (pre-fetched content) |
 | [04-custom-extractors.ts](./04-custom-extractors.ts) | Build custom extractors for domain-specific data |
-| [22-normalize-text.ts](./22-normalize-text.ts) | Normalize text with boilerplate removal and metadata |
 
 ### LLM Integration
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,18 @@
+# Lefthook configuration
+# https://github.com/evilmartians/lefthook
+
+pre-commit:
+  parallel: true
+  commands:
+    lint-format:
+      glob: "*.{js,ts,mjs,mts,cjs,cts,jsx,tsx,json}"
+      run: npx biome check --write {staged_files}
+      stage_fixed: true
+
+pre-push:
+  parallel: false
+  commands:
+    type-check:
+      run: npm run type-check
+    test:
+      run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scrapex",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scrapex",
-      "version": "1.0.0-beta.2",
+      "version": "1.0.0-beta.4",
       "license": "MIT",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",
@@ -24,6 +24,7 @@
         "@types/mdast": "^4.0.4",
         "@types/node": "^22.10.0",
         "@types/turndown": "^5.0.6",
+        "lefthook": "^2.0.13",
         "tsdown": "^0.18.4",
         "typescript": "^5.9.3",
         "vitest": "^4.0.16"
@@ -2913,6 +2914,158 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "optional": true,
       "peer": true
+    },
+    "node_modules/lefthook": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/lefthook/-/lefthook-2.0.13.tgz",
+      "integrity": "sha512-D39rCVl7/GpqakvhQvqz07SBpzUWTvWjXKnBZyIy8O6D+Lf9xD6tnbHtG5nWXd9iPvv1AKGQwL9R/e5rNtV6SQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "lefthook": "bin/index.js"
+      },
+      "optionalDependencies": {
+        "lefthook-darwin-arm64": "2.0.13",
+        "lefthook-darwin-x64": "2.0.13",
+        "lefthook-freebsd-arm64": "2.0.13",
+        "lefthook-freebsd-x64": "2.0.13",
+        "lefthook-linux-arm64": "2.0.13",
+        "lefthook-linux-x64": "2.0.13",
+        "lefthook-openbsd-arm64": "2.0.13",
+        "lefthook-openbsd-x64": "2.0.13",
+        "lefthook-windows-arm64": "2.0.13",
+        "lefthook-windows-x64": "2.0.13"
+      }
+    },
+    "node_modules/lefthook-darwin-arm64": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-arm64/-/lefthook-darwin-arm64-2.0.13.tgz",
+      "integrity": "sha512-KbQqpNSNTugjtPzt97CNcy/XZy5asJ0+uSLoHc4ML8UCJdsXKYJGozJHNwAd0Xfci/rQlj82A7rPOuTdh0jY0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/lefthook-darwin-x64": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-x64/-/lefthook-darwin-x64-2.0.13.tgz",
+      "integrity": "sha512-s/vI6sEE8/+rE6CONZzs59LxyuSc/KdU+/3adkNx+Q13R1+p/AvQNeszg3LAHzXmF3NqlxYf8jbj/z5vBzEpRw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/lefthook-freebsd-arm64": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-arm64/-/lefthook-freebsd-arm64-2.0.13.tgz",
+      "integrity": "sha512-iQeJTU7Zl8EJlCMQxNZQpJFAQ9xl40pydUIv5SYnbJ4nqIr9ONuvrioNv6N2LtKP5aBl1nIWQQ9vMjgVyb3k+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/lefthook-freebsd-x64": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-x64/-/lefthook-freebsd-x64-2.0.13.tgz",
+      "integrity": "sha512-99cAXKRIzpq/u3obUXbOQJCHP+0ZkJbN3TF+1ZQZlRo3Y6+mPSCg9fh/oi6dgbtu4gTI5Ifz3o5p2KZzAIF9ZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/lefthook-linux-arm64": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-arm64/-/lefthook-linux-arm64-2.0.13.tgz",
+      "integrity": "sha512-RWarenY3kLy/DT4/8dY2bwDlYwlELRq9MIFq+FiMYmoBHES3ckWcLX2JMMlM49Y672paQc7MbneSrNUn/FQWhg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/lefthook-linux-x64": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-x64/-/lefthook-linux-x64-2.0.13.tgz",
+      "integrity": "sha512-QZRcxXGf8Uj/75ITBqoBh0zWhJE7+uFoRxEHwBq0Qjv55Q4KcFm7FBN/IFQCSd14reY5pmY3kDaWVVy60cAGJA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/lefthook-openbsd-arm64": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/lefthook-openbsd-arm64/-/lefthook-openbsd-arm64-2.0.13.tgz",
+      "integrity": "sha512-LAuOWwnNmOlRE0RxKMOhIz5Kr9tXi0rCjzXtDARW9lvfAV6Br2wP+47q0rqQ8m/nVwBYoxfJ/RDunLbb86O1nA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/lefthook-openbsd-x64": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/lefthook-openbsd-x64/-/lefthook-openbsd-x64-2.0.13.tgz",
+      "integrity": "sha512-n9TIN3QLncyxOHomiKKwzDFHKOCm5H28CVNAZFouKqDwEaUGCs5TJI88V85j4/CgmLVUU8uUn4ClVCxIWYG59w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/lefthook-windows-arm64": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-arm64/-/lefthook-windows-arm64-2.0.13.tgz",
+      "integrity": "sha512-sdSC4F9Di7y0t43Of9MOA5g/0CmvkM4juQ3sKfUhRcoygetLJn4PR2/pvuDOIaGf4mNMXBP5IrcKaeDON9HrcA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/lefthook-windows-x64": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-x64/-/lefthook-windows-x64-2.0.13.tgz",
+      "integrity": "sha512-ccl1v7Fl10qYoghEtjXN+JC1x/y/zLM/NSHf3NFGeKEGBNd1P5d/j6w8zVmhfzi+ekS8whXrcNbRAkLdAqUrSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "dist"
   ],
   "scripts": {
+    "prepare": "lefthook install",
     "dev": "tsdown --watch",
     "build": "tsdown",
     "test": "vitest run",
@@ -83,6 +84,7 @@
     "@types/mdast": "^4.0.4",
     "@types/node": "^22.10.0",
     "@types/turndown": "^5.0.6",
+    "lefthook": "^2.0.13",
     "tsdown": "^0.18.4",
     "typescript": "^5.9.3",
     "vitest": "^4.0.16"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrapex",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.4",
   "description": "Modern web scraper with LLM-enhanced extraction, extensible pipeline, and pluggable parsers",
   "type": "module",
   "exports": {

--- a/src/content/blocks.ts
+++ b/src/content/blocks.ts
@@ -25,7 +25,7 @@ const BLOCK_TYPE_SELECTORS: Record<string, BlockType> = {
   '.legal, .disclaimer, .terms, .copyright': 'legal',
   'blockquote, q': 'quote',
   'pre, code': 'code',
-  'table': 'table',
+  table: 'table',
   'ul, ol, dl, li, dt, dd': 'list',
   'figure, img, video, audio, picture': 'media',
   figcaption: 'paragraph',

--- a/src/content/blocks.ts
+++ b/src/content/blocks.ts
@@ -142,17 +142,20 @@ export function parseBlocks(
     if (type === 'media') {
       const img = $el.is('img') ? $el : $el.find('img').first();
       if (img.length) {
-        block.attrs = {
-          alt: img.attr('alt') || '',
-          src: img.attr('src') || '',
-        };
+        const alt = img.attr('alt');
+        const src = img.attr('src');
+        block.attrs = {};
+        if (alt) block.attrs.alt = alt;
+        if (src) block.attrs.src = src;
       } else {
         const video = $el.is('video') ? $el : $el.find('video').first();
         if (video.length) {
-          block.attrs = {
-            src: video.attr('src') || video.find('source').first().attr('src') || '',
-            poster: video.attr('poster') || '',
-          };
+          // Only the first <source> is captured for video elements.
+          const src = video.attr('src') || video.find('source').first().attr('src');
+          const poster = video.attr('poster');
+          block.attrs = {};
+          if (src) block.attrs.src = src;
+          if (poster) block.attrs.poster = poster;
         }
       }
     }

--- a/src/content/blocks.ts
+++ b/src/content/blocks.ts
@@ -107,8 +107,9 @@ export function parseBlocks(
     }
 
     // Avoid duplicates from nested elements by preferring the most granular blocks
+    // Include li, dt, dd so list containers (ul, ol, dl) are skipped in favor of their items
     const hasBlockChildren =
-      $el.find('p, h1, h2, h3, h4, h5, h6, ul, ol, blockquote, pre, table').length > 0;
+      $el.find('p, h1, h2, h3, h4, h5, h6, ul, ol, li, dt, dd, blockquote, pre, table').length > 0;
     if (hasBlockChildren) {
       return; // Skip containers, process children instead
     }

--- a/src/content/blocks.ts
+++ b/src/content/blocks.ts
@@ -1,0 +1,151 @@
+import type { CheerioAPI } from 'cheerio';
+import type { BlockType, ContentBlock } from './types.js';
+
+/**
+ * Default selectors to drop before block parsing.
+ */
+export const DEFAULT_DROP_SELECTORS = [
+  'script',
+  'style',
+  'noscript',
+  'iframe',
+  'svg',
+  'canvas',
+  '[hidden]',
+  '[aria-hidden="true"]',
+];
+
+/**
+ * Selectors for block type detection.
+ */
+const BLOCK_TYPE_SELECTORS: Record<string, BlockType> = {
+  'nav, [role="navigation"]': 'nav',
+  'footer, [role="contentinfo"]': 'footer',
+  'aside.promo, .advertisement, .ad, [data-ad]': 'promo',
+  '.legal, .disclaimer, .terms, .copyright': 'legal',
+  'blockquote, q': 'quote',
+  'pre, code': 'code',
+  'table': 'table',
+  'ul, ol, dl, li, dt, dd': 'list',
+  'figure, img, video, audio, picture': 'media',
+  figcaption: 'paragraph',
+  h1: 'heading',
+  h2: 'heading',
+  h3: 'heading',
+  h4: 'heading',
+  h5: 'heading',
+  h6: 'heading',
+  p: 'paragraph',
+};
+
+/**
+ * Parse HTML into content blocks.
+ */
+export function parseBlocks(
+  $: CheerioAPI,
+  options: {
+    dropSelectors?: string[];
+    maxBlocks?: number;
+    includeHtml?: boolean;
+  } = {}
+): ContentBlock[] {
+  const { dropSelectors = [], maxBlocks = 2000, includeHtml = false } = options;
+  const blocks: ContentBlock[] = [];
+
+  // Remove unwanted elements
+  const allDropSelectors = [...DEFAULT_DROP_SELECTORS, ...dropSelectors];
+  $(allDropSelectors.join(', ')).remove();
+
+  // Find content container
+  const contentArea = $('article, main, [role="main"], .content, #content').first();
+  const container = contentArea.length > 0 ? contentArea : $('body');
+
+  // Process block-level elements.
+  // Note: find('*') can be expensive on very large DOMs; maxBlocks provides a hard stop.
+  container.find('*').each((_, el) => {
+    if (blocks.length >= maxBlocks) {
+      return false;
+    }
+    const $el = $(el);
+    const tagName = el.tagName?.toLowerCase();
+
+    if (!tagName) {
+      return;
+    }
+
+    // Determine block type
+    let type: BlockType = 'unknown';
+    let level: 1 | 2 | 3 | 4 | 5 | 6 | undefined;
+
+    // Check structural types first
+    for (const [selector, blockType] of Object.entries(BLOCK_TYPE_SELECTORS)) {
+      if ($el.is(selector)) {
+        type = blockType;
+        break;
+      }
+    }
+
+    // Extract heading level
+    const headingMatch = tagName.match(/^h([1-6])$/);
+    if (headingMatch?.[1]) {
+      type = 'heading';
+      level = Number.parseInt(headingMatch[1], 10) as 1 | 2 | 3 | 4 | 5 | 6;
+    }
+
+    // Skip non-block elements
+    if (
+      type === 'unknown' &&
+      !['p', 'div', 'section', 'article', 'li', 'dt', 'dd', 'figcaption'].includes(tagName)
+    ) {
+      return;
+    }
+
+    // Get text content
+    const text = $el.text().trim();
+    if (!text) {
+      return;
+    }
+
+    // Avoid duplicates from nested elements by preferring the most granular blocks
+    const hasBlockChildren =
+      $el.find('p, h1, h2, h3, h4, h5, h6, ul, ol, blockquote, pre, table').length > 0;
+    if (hasBlockChildren) {
+      return; // Skip containers, process children instead
+    }
+
+    // Build block
+    const parentTags = $el
+      .parents()
+      .map((_, p) => p.tagName?.toLowerCase())
+      .get()
+      .reverse();
+    const block: ContentBlock = {
+      type: type === 'unknown' ? 'paragraph' : type,
+      text,
+      ...(level && { level }),
+      context: {
+        parentTags,
+        depth: parentTags.length,
+      },
+    };
+
+    if (includeHtml) {
+      block.html = $el.html() || undefined;
+    }
+
+    // Add attrs for media
+    if (type === 'media') {
+      const img = $el.is('img') ? $el : $el.find('img').first();
+      if (img.length) {
+        block.attrs = {
+          alt: img.attr('alt') || '',
+          src: img.attr('src') || '',
+        };
+      }
+    }
+
+    blocks.push(block);
+  });
+
+  return blocks;
+}

--- a/src/content/classifier.ts
+++ b/src/content/classifier.ts
@@ -1,8 +1,4 @@
-import type {
-  ClassifierResult,
-  ContentBlock,
-  ContentBlockClassifier,
-} from './types.js';
+import type { ClassifierResult, ContentBlock, ContentBlockClassifier } from './types.js';
 
 /**
  * Default site-agnostic block classifier.
@@ -98,7 +94,11 @@ export function combineClassifiers(
     return {
       accept: true,
       score: avgScore,
-      label: results.map((result) => result.label).filter(Boolean).join('+') || 'content',
+      label:
+        results
+          .map((result) => result.label)
+          .filter(Boolean)
+          .join('+') || 'content',
     };
   };
 }

--- a/src/content/classifier.ts
+++ b/src/content/classifier.ts
@@ -35,16 +35,18 @@ export const defaultBlockClassifier: ContentBlockClassifier = (
     return { accept: false, label: 'boilerplate' };
   }
 
-  // Very short fragments (likely UI elements or captions)
-  const isShort = text.length < 20;
-  const endsWithPunct = /[.!?]\s*$/.test(text);
-  if (isShort && block.type !== 'heading' && block.type !== 'list' && !endsWithPunct) {
-    return { accept: false, label: 'too-short' };
-  }
-
-  // Media credits/captions
+  // Media credits/captions (check before too-short to get correct label)
   if (/\b(photo by|image:|credit:|source:)\b/i.test(lowerText) && text.length < 120) {
     return { accept: false, label: 'media-credit' };
+  }
+
+  // Very short fragments (likely UI elements or captions)
+  // Exempt headings, lists, quotes, and code which are meaningful at any length
+  const isShort = text.length < 20;
+  const endsWithPunct = /[.!?]\s*$/.test(text);
+  const exemptTypes = ['heading', 'list', 'quote', 'code'];
+  if (isShort && !exemptTypes.includes(block.type) && !endsWithPunct) {
+    return { accept: false, label: 'too-short' };
   }
 
   // Calculate relevance score based on block characteristics

--- a/src/content/classifier.ts
+++ b/src/content/classifier.ts
@@ -1,0 +1,104 @@
+import type {
+  ClassifierResult,
+  ContentBlock,
+  ContentBlockClassifier,
+} from './types.js';
+
+/**
+ * Default site-agnostic block classifier.
+ * Filters navigation, footers, boilerplate, and short fragments.
+ */
+export const defaultBlockClassifier: ContentBlockClassifier = (
+  block: ContentBlock
+): ClassifierResult => {
+  const text = (block.text || '').trim();
+  const lowerText = text.toLowerCase().slice(0, 1000); // limit regex input
+
+  // Empty blocks
+  if (!text) {
+    return { accept: false, label: 'empty' };
+  }
+
+  // Structural boilerplate
+  if (block.type === 'nav') return { accept: false, label: 'nav' };
+  if (block.type === 'footer') return { accept: false, label: 'footer' };
+  if (block.type === 'legal') return { accept: false, label: 'legal' };
+  if (block.type === 'promo') return { accept: false, label: 'promo' };
+
+  // Generic boilerplate phrases (not site-specific)
+  const boilerplatePatterns = [
+    /\b(subscribe|sign up|newsletter|notifications|follow us)\b/i,
+    /\b(sponsored|advertis(e|ement|ing)|promotion|partner content)\b/i,
+    /\b(read more|keep reading|continue reading|see more)\b/i,
+    /\b(cookie policy|privacy policy|terms of service|all rights reserved)\b/i,
+    /\b(share on|share this|tweet this|pin it)\b/i,
+    /\b(comments?|leave a reply|join the discussion)\b/i,
+  ];
+
+  if (boilerplatePatterns.some((re) => re.test(lowerText))) {
+    return { accept: false, label: 'boilerplate' };
+  }
+
+  // Very short fragments (likely UI elements or captions)
+  const isShort = text.length < 20;
+  const endsWithPunct = /[.!?]\s*$/.test(text);
+  if (isShort && block.type !== 'heading' && block.type !== 'list' && !endsWithPunct) {
+    return { accept: false, label: 'too-short' };
+  }
+
+  // Media credits/captions
+  if (/\b(photo by|image:|credit:|source:)\b/i.test(lowerText) && text.length < 120) {
+    return { accept: false, label: 'media-credit' };
+  }
+
+  // Calculate relevance score based on block characteristics
+  let score = 0.5;
+
+  // Headings are important
+  if (block.type === 'heading') {
+    score = block.level === 1 ? 0.9 : block.level === 2 ? 0.8 : 0.7;
+  }
+
+  // Longer paragraphs are typically more substantive
+  if (block.type === 'paragraph') {
+    score = Math.min(0.9, 0.5 + text.length / 1000);
+  }
+
+  // Quotes and code are often important
+  if (block.type === 'quote' || block.type === 'code') {
+    score = 0.7;
+  }
+
+  return { accept: true, label: 'content', score };
+};
+
+/**
+ * Create a classifier that combines multiple classifiers.
+ * First classifier to reject wins; scores are averaged.
+ */
+export function combineClassifiers(
+  ...classifiers: ContentBlockClassifier[]
+): ContentBlockClassifier {
+  // AND semantics: first rejection wins. For OR, wrap with a custom helper.
+  return async (block, context) => {
+    const results: ClassifierResult[] = [];
+
+    for (const classifier of classifiers) {
+      const result = await classifier(block, context);
+      if (!result.accept) {
+        return result; // Early exit on rejection
+      }
+      results.push(result);
+    }
+
+    const scores = results.map((result) => result.score).filter((score) => score !== undefined);
+    const avgScore =
+      scores.length > 0 ? scores.reduce((sum, score) => sum + score, 0) / scores.length : undefined;
+
+    return {
+      accept: true,
+      score: avgScore,
+      label: results.map((result) => result.label).filter(Boolean).join('+') || 'content',
+    };
+  };
+}

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -1,5 +1,5 @@
-export { parseBlocks, DEFAULT_DROP_SELECTORS } from './blocks.js';
-export { defaultBlockClassifier, combineClassifiers } from './classifier.js';
+export { DEFAULT_DROP_SELECTORS, parseBlocks } from './blocks.js';
+export { combineClassifiers, defaultBlockClassifier } from './classifier.js';
 export { normalizeText } from './normalizer.js';
 export type {
   BlockType,
@@ -7,8 +7,8 @@ export type {
   ClassifierResult,
   ContentBlock,
   ContentBlockClassifier,
+  NormalizationMeta,
   NormalizeOptions,
   NormalizeResult,
-  NormalizationMeta,
   TruncateStrategy,
 } from './types.js';

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -1,0 +1,14 @@
+export { parseBlocks, DEFAULT_DROP_SELECTORS } from './blocks.js';
+export { defaultBlockClassifier, combineClassifiers } from './classifier.js';
+export { normalizeText } from './normalizer.js';
+export type {
+  BlockType,
+  ClassifierContext,
+  ClassifierResult,
+  ContentBlock,
+  ContentBlockClassifier,
+  NormalizeOptions,
+  NormalizeResult,
+  NormalizationMeta,
+  TruncateStrategy,
+} from './types.js';

--- a/src/content/normalizer.ts
+++ b/src/content/normalizer.ts
@@ -1,13 +1,13 @@
 import { createHash } from 'node:crypto';
+import { defaultBlockClassifier } from './classifier.js';
 import type {
   ClassifierContext,
   ContentBlock,
   ContentBlockClassifier,
+  NormalizationMeta,
   NormalizeOptions,
   NormalizeResult,
-  NormalizationMeta,
 } from './types.js';
-import { defaultBlockClassifier } from './classifier.js';
 
 /**
  * Normalize text with optional HTML entity decoding and Unicode normalization.
@@ -30,9 +30,7 @@ function normalizeString(
       .replace(/&gt;/g, '>')
       .replace(/&quot;/g, '"')
       .replace(/&#(\d+);/g, (_, code) => String.fromCharCode(Number.parseInt(code, 10)))
-      .replace(/&#x([0-9a-f]+);/gi, (_, code) =>
-        String.fromCharCode(Number.parseInt(code, 16))
-      );
+      .replace(/&#x([0-9a-f]+);/gi, (_, code) => String.fromCharCode(Number.parseInt(code, 16)));
   }
 
   // Strip markdown links, keep text

--- a/src/content/normalizer.ts
+++ b/src/content/normalizer.ts
@@ -1,0 +1,212 @@
+import { createHash } from 'node:crypto';
+import type {
+  ClassifierContext,
+  ContentBlock,
+  ContentBlockClassifier,
+  NormalizeOptions,
+  NormalizeResult,
+  NormalizationMeta,
+} from './types.js';
+import { defaultBlockClassifier } from './classifier.js';
+
+/**
+ * Normalize text with optional HTML entity decoding and Unicode normalization.
+ */
+function normalizeString(
+  text: string,
+  options: Pick<
+    NormalizeOptions,
+    'decodeEntities' | 'normalizeUnicode' | 'preserveLineBreaks' | 'stripLinks'
+  >
+): string {
+  let result = text;
+
+  // Decode HTML entities
+  if (options.decodeEntities !== false) {
+    result = result
+      .replace(/&nbsp;/g, ' ')
+      .replace(/&amp;/g, '&')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/&#(\d+);/g, (_, code) => String.fromCharCode(Number.parseInt(code, 10)))
+      .replace(/&#x([0-9a-f]+);/gi, (_, code) =>
+        String.fromCharCode(Number.parseInt(code, 16))
+      );
+  }
+
+  // Strip markdown links, keep text
+  if (options.stripLinks !== false) {
+    result = result.replace(/\[([^\]]+)\]\([^)]+\)/g, '$1');
+  }
+
+  // Normalize Unicode
+  if (options.normalizeUnicode !== false) {
+    result = result.normalize('NFC');
+  }
+
+  // Collapse whitespace
+  result = result.replace(/[ \t]+/g, ' ');
+
+  // Handle line breaks
+  if (options.preserveLineBreaks !== false) {
+    result = result.replace(/\n{3,}/g, '\n\n'); // Max 2 consecutive newlines
+  } else {
+    result = result.replace(/\n+/g, ' ');
+  }
+
+  return result.trim();
+}
+
+/**
+ * Truncate text at natural boundaries.
+ */
+function truncateText(
+  text: string,
+  maxChars: number,
+  strategy: 'sentence' | 'word' | 'char'
+): { text: string; truncated: boolean } {
+  if (text.length <= maxChars) {
+    return { text, truncated: false };
+  }
+
+  let truncated = text.slice(0, maxChars);
+
+  if (strategy === 'sentence') {
+    const sentenceEnd = truncated.lastIndexOf('. ');
+    const questionEnd = truncated.lastIndexOf('? ');
+    const exclamEnd = truncated.lastIndexOf('! ');
+    const lastBoundary = Math.max(sentenceEnd, questionEnd, exclamEnd);
+
+    if (lastBoundary > maxChars * 0.5) {
+      truncated = truncated.slice(0, lastBoundary + 1);
+    }
+  } else if (strategy === 'word') {
+    const lastSpace = truncated.lastIndexOf(' ');
+    if (lastSpace > maxChars * 0.8) {
+      truncated = truncated.slice(0, lastSpace);
+    }
+  }
+
+  return { text: truncated.trim(), truncated: true };
+}
+
+/**
+ * Generate content hash for deduplication.
+ * Use at least 128-bit output to reduce collision risk at scale.
+ */
+function generateHash(text: string): string {
+  return createHash('sha256').update(text).digest('hex').slice(0, 32);
+}
+
+/**
+ * Normalize content blocks into clean text.
+ */
+export async function normalizeText(
+  blocks: ContentBlock[],
+  options: NormalizeOptions = {},
+  url?: string
+): Promise<NormalizeResult> {
+  const startTime = Date.now();
+  const {
+    mode = 'full',
+    maxChars,
+    minChars,
+    truncate = 'sentence',
+    removeBoilerplate = true,
+    debug = false,
+  } = options;
+
+  const classifier: ContentBlockClassifier | undefined =
+    options.blockClassifier ?? (removeBoilerplate ? defaultBlockClassifier : undefined);
+
+  let classifiedBlocks: Array<ContentBlock & { score?: number; label?: string }> = [];
+
+  if (classifier) {
+    for (let i = 0; i < blocks.length; i++) {
+      const block = blocks[i];
+      if (!block) continue;
+
+      const context: ClassifierContext = {
+        index: i,
+        totalBlocks: blocks.length,
+        url,
+        parentTags: block.context?.parentTags,
+        depth: block.context?.depth,
+      };
+
+      const result = await classifier(block, context);
+
+      if (result.accept) {
+        classifiedBlocks.push({
+          ...block,
+          score: result.score,
+          label: result.label,
+        });
+      }
+    }
+  } else {
+    classifiedBlocks = blocks.map((block) => ({ ...block }));
+  }
+
+  if (mode === 'summary') {
+    classifiedBlocks.sort((a, b) => (b.score ?? 0.5) - (a.score ?? 0.5));
+  }
+
+  const textParts = classifiedBlocks.map((block) => {
+    let text = normalizeString(block.text, options);
+
+    if (block.type === 'heading' && block.level) {
+      text = `${'#'.repeat(block.level)} ${text}`;
+    }
+
+    return text;
+  });
+
+  let normalizedText = textParts.join('\n\n');
+
+  let truncated = false;
+  if (maxChars && normalizedText.length > maxChars) {
+    const result = truncateText(normalizedText, maxChars, truncate);
+    normalizedText = result.text;
+    truncated = result.truncated;
+  }
+
+  if (minChars && normalizedText.length < minChars) {
+    return {
+      text: '',
+      meta: {
+        charCount: 0,
+        tokenEstimate: 0,
+        language: options.languageHint || 'unknown',
+        boilerplateRemoved: false,
+        classifierUsed: false,
+        hash: '',
+        extractionTimeMs: Date.now() - startTime,
+        blocksTotal: blocks.length,
+        blocksAccepted: 0,
+        truncated: false,
+      },
+      ...(debug && { blocks: [] }),
+    };
+  }
+
+  const meta: NormalizationMeta = {
+    charCount: normalizedText.length,
+    tokenEstimate: Math.ceil(normalizedText.length / 4),
+    language: options.languageHint || 'unknown',
+    boilerplateRemoved: removeBoilerplate,
+    classifierUsed: !!classifier,
+    hash: generateHash(normalizedText),
+    extractionTimeMs: Date.now() - startTime,
+    blocksTotal: blocks.length,
+    blocksAccepted: classifiedBlocks.length,
+    truncated,
+  };
+
+  return {
+    text: normalizedText,
+    meta,
+    ...(debug && { blocks: classifiedBlocks }),
+  };
+}

--- a/src/content/types.ts
+++ b/src/content/types.ts
@@ -1,0 +1,153 @@
+/**
+ * Block type classification for content blocks.
+ */
+export type BlockType =
+  | 'paragraph'
+  | 'heading'
+  | 'list'
+  | 'quote'
+  | 'table'
+  | 'code'
+  | 'media'
+  | 'nav'
+  | 'footer'
+  | 'promo'
+  | 'legal'
+  | 'unknown';
+
+/**
+ * A classified content block extracted from HTML.
+ */
+export interface ContentBlock {
+  /** Block type classification */
+  type: BlockType;
+  /** Plain text content */
+  text: string;
+  /** Heading level (1-6) when type is 'heading' */
+  level?: 1 | 2 | 3 | 4 | 5 | 6;
+  /** Original HTML (unsafe; sanitize before rendering). Unset by default. */
+  html?: string;
+  /** Additional attributes (e.g., alt text, href) */
+  attrs?: Record<string, string>;
+  /** Optional structural context from DOM */
+  context?: {
+    parentTags?: string[];
+    depth?: number;
+  };
+}
+
+/**
+ * Result of block classification.
+ */
+export interface ClassifierResult {
+  /** Whether to include this block in normalized output */
+  accept: boolean;
+  /** Relevance score (0-1) for ranking in summary mode */
+  score?: number;
+  /** Classification label for analytics/debugging */
+  label?: string;
+}
+
+/**
+ * Context provided to block classifiers.
+ */
+export interface ClassifierContext {
+  /** Zero-based index of block in array */
+  index: number;
+  /** Total number of blocks */
+  totalBlocks: number;
+  /** Source URL (for domain-specific rules) */
+  url?: string;
+  /** Parent tag chain (e.g., ['body', 'main', 'aside']) */
+  parentTags?: string[];
+  /** Nesting depth in DOM */
+  depth?: number;
+}
+
+/**
+ * Block classifier function signature.
+ * Supports both sync and async classifiers (for LLM-based classification).
+ */
+export type ContentBlockClassifier = (
+  block: ContentBlock,
+  context: ClassifierContext
+) => ClassifierResult | Promise<ClassifierResult>;
+
+/**
+ * Truncation strategy for maxChars limit.
+ */
+export type TruncateStrategy = 'sentence' | 'word' | 'char';
+
+/**
+ * Options for text normalization.
+ */
+export interface NormalizeOptions {
+  /** Output mode: 'summary' uses scores to rank blocks, 'full' keeps all accepted */
+  mode?: 'summary' | 'full';
+  /** Maximum characters in output (applied after normalization) */
+  maxChars?: number;
+  /** Minimum characters required (skips normalization if content too short) */
+  minChars?: number;
+  /** Maximum blocks to process (default: 2000) */
+  maxBlocks?: number;
+  /** How to truncate when maxChars exceeded (default: 'sentence') */
+  truncate?: TruncateStrategy;
+  /** CSS selectors to drop before block parsing */
+  dropSelectors?: string[];
+  /** Apply default boilerplate removal (default: true) */
+  removeBoilerplate?: boolean;
+  /** Decode HTML entities (default: true) */
+  decodeEntities?: boolean;
+  /** Normalize Unicode to NFC (default: true) */
+  normalizeUnicode?: boolean;
+  /** Preserve paragraph breaks as double newlines (default: true) */
+  preserveLineBreaks?: boolean;
+  /** Strip markdown-style links, keep text (default: true) */
+  stripLinks?: boolean;
+  /** Include original HTML in blocks (default: false) */
+  includeHtml?: boolean;
+  /** Language hint for future i18n support */
+  languageHint?: string;
+  /** Custom block classifier (overrides default when provided) */
+  blockClassifier?: ContentBlockClassifier;
+  /** Include blocks array in output for debugging (default: false) */
+  debug?: boolean;
+}
+
+/**
+ * Metadata about the normalization process.
+ */
+export interface NormalizationMeta {
+  /** Character count of normalized text */
+  charCount: number;
+  /** Estimated token count (chars/4 heuristic) */
+  tokenEstimate: number;
+  /** Detected or hinted language */
+  language: string;
+  /** Whether boilerplate removal was applied */
+  boilerplateRemoved: boolean;
+  /** Whether a classifier (custom or default) was used */
+  classifierUsed: boolean;
+  /** Content hash for deduplication (SHA-256, first 32 chars) */
+  hash: string;
+  /** Normalization time in milliseconds */
+  extractionTimeMs: number;
+  /** Number of blocks before classification */
+  blocksTotal: number;
+  /** Number of blocks accepted after classification */
+  blocksAccepted: number;
+  /** Whether output was truncated */
+  truncated: boolean;
+}
+
+/**
+ * Result of normalizeText() standalone function.
+ */
+export interface NormalizeResult {
+  /** Normalized plain text output */
+  text: string;
+  /** Normalization metadata */
+  meta: NormalizationMeta;
+  /** Classified blocks (only when debug: true) */
+  blocks?: ContentBlock[];
+}

--- a/src/core/scrape.ts
+++ b/src/core/scrape.ts
@@ -1,8 +1,8 @@
+import { normalizeText, parseBlocks } from '@/content/index.js';
 import { generateEmbeddings } from '@/embeddings/pipeline.js';
 import { createDefaultExtractors, sortExtractors } from '@/extractors/index.js';
 import { checkRobotsTxt, defaultFetcher } from '@/fetchers/index.js';
 import { enhance, extract } from '@/llm/enhancer.js';
-import { normalizeText, parseBlocks } from '@/content/index.js';
 import { extractDomain, isValidUrl, normalizeUrl } from '@/utils/url.js';
 import { createExtractionContext, mergeResults, preloadJsdom } from './context.js';
 import { ScrapeError } from './errors.js';

--- a/src/core/scrape.ts
+++ b/src/core/scrape.ts
@@ -2,10 +2,11 @@ import { generateEmbeddings } from '@/embeddings/pipeline.js';
 import { createDefaultExtractors, sortExtractors } from '@/extractors/index.js';
 import { checkRobotsTxt, defaultFetcher } from '@/fetchers/index.js';
 import { enhance, extract } from '@/llm/enhancer.js';
+import { normalizeText, parseBlocks } from '@/content/index.js';
 import { extractDomain, isValidUrl, normalizeUrl } from '@/utils/url.js';
 import { createExtractionContext, mergeResults, preloadJsdom } from './context.js';
 import { ScrapeError } from './errors.js';
-import type { Extractor, ScrapedData, ScrapeOptions } from './types.js';
+import type { ExtractionContext, Extractor, ScrapedData, ScrapeOptions } from './types.js';
 
 async function applyLlmProcessing(result: ScrapedData, options: ScrapeOptions): Promise<void> {
   // LLM Enhancement
@@ -32,6 +33,39 @@ async function applyLlmProcessing(result: ScrapedData, options: ScrapeOptions): 
         ? `${result.error}; LLM extraction: ${error instanceof Error ? error.message : String(error)}`
         : `LLM extraction: ${error instanceof Error ? error.message : String(error)}`;
     }
+  }
+}
+
+async function applyNormalization(
+  result: ScrapedData,
+  context: ExtractionContext,
+  options: ScrapeOptions,
+  url: string
+): Promise<void> {
+  if (!options.normalize) {
+    return;
+  }
+
+  try {
+    const blocks = parseBlocks(context.$, {
+      dropSelectors: options.normalize.dropSelectors,
+      maxBlocks: options.normalize.maxBlocks,
+      includeHtml: options.normalize.includeHtml,
+    });
+
+    const normalizeResult = await normalizeText(blocks, options.normalize, url);
+
+    result.normalizedText = normalizeResult.text;
+    result.normalizationMeta = normalizeResult.meta;
+
+    if (options.normalize.debug && normalizeResult.blocks) {
+      result.normalizedBlocks = normalizeResult.blocks;
+    }
+  } catch (error) {
+    console.error('Normalization failed:', error);
+    result.error = result.error
+      ? `${result.error}; normalize: ${error instanceof Error ? error.message : String(error)}`
+      : `normalize: ${error instanceof Error ? error.message : String(error)}`;
   }
 }
 
@@ -143,6 +177,9 @@ export async function scrape(url: string, options: ScrapeOptions = {}): Promise<
     scrapeTimeMs: 0,
     error: context.results.error,
   };
+
+  // Normalization (after extraction, before LLM)
+  await applyNormalization(intermediateResult, context, options, normalizedUrl);
 
   // LLM Enhancement and Extraction
   await applyLlmProcessing(intermediateResult, options);
@@ -260,6 +297,9 @@ export async function scrapeHtml(
     scrapeTimeMs: 0,
     error: context.results.error,
   };
+
+  // Normalization (after extraction, before LLM)
+  await applyNormalization(intermediateResult, context, options, normalizedUrl);
 
   // LLM Enhancement and Extraction
   await applyLlmProcessing(intermediateResult, options);

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,5 +1,5 @@
 import type { CheerioAPI } from 'cheerio';
-import type { ContentBlock, NormalizeOptions, NormalizationMeta } from '../content/types.js';
+import type { ContentBlock, NormalizationMeta, NormalizeOptions } from '../content/types.js';
 import type { EmbeddingOptions, EmbeddingResult } from '../embeddings/types.js';
 
 /**

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,4 +1,5 @@
 import type { CheerioAPI } from 'cheerio';
+import type { ContentBlock, NormalizeOptions, NormalizationMeta } from '../content/types.js';
 import type { EmbeddingOptions, EmbeddingResult } from '../embeddings/types.js';
 
 /**
@@ -83,6 +84,11 @@ export interface ScrapedData {
 
   // Embeddings (optional)
   embeddings?: EmbeddingResult;
+
+  // Normalized text (optional)
+  normalizedText?: string;
+  normalizationMeta?: NormalizationMeta;
+  normalizedBlocks?: ContentBlock[];
 
   // Meta
   scrapedAt: string;
@@ -215,4 +221,7 @@ export interface ScrapeOptions {
 
   /** Embedding generation options */
   embeddings?: EmbeddingOptions;
+
+  /** Text normalization options */
+  normalize?: NormalizeOptions;
 }

--- a/src/embeddings/input.ts
+++ b/src/embeddings/input.ts
@@ -10,17 +10,22 @@ import type { EmbeddingInputConfig } from './types.js';
  */
 export function selectInput(
   data: Partial<ScrapedData>,
-  config?: EmbeddingInputConfig
+  config?: EmbeddingInputConfig,
+  preferNormalized = true
 ): string | undefined {
+  if (preferNormalized && data.normalizedText?.trim()) {
+    return cleanText(data.normalizedText);
+  }
+
   // If transform function is provided, use it directly
   if (config?.transform) {
     const transformed = config.transform(data);
-    return normalizeText(transformed);
+    return cleanText(transformed);
   }
 
   // If custom text is provided and type is 'custom', use it
   if (config?.type === 'custom' && config.customText) {
-    return normalizeText(config.customText);
+    return cleanText(config.customText);
   }
 
   // Select based on type
@@ -50,20 +55,20 @@ export function selectInput(
  */
 function selectTextContent(data: Partial<ScrapedData>): string | undefined {
   if (data.textContent) {
-    return normalizeText(data.textContent);
+      return cleanText(data.textContent);
   }
 
   // Fallback chain: content (markdown) -> excerpt -> description
   if (data.content) {
-    return normalizeText(stripMarkdown(data.content));
+    return cleanText(stripMarkdown(data.content));
   }
 
   if (data.excerpt) {
-    return normalizeText(data.excerpt);
+    return cleanText(data.excerpt);
   }
 
   if (data.description) {
-    return normalizeText(data.description);
+    return cleanText(data.description);
   }
 
   return undefined;
@@ -94,7 +99,7 @@ function selectTitleSummary(data: Partial<ScrapedData>): string | undefined {
     return undefined;
   }
 
-  return normalizeText(parts.join('\n\n'));
+  return cleanText(parts.join('\n\n'));
 }
 
 /**
@@ -103,7 +108,7 @@ function selectTitleSummary(data: Partial<ScrapedData>): string | undefined {
  * - Trim leading/trailing whitespace
  * - Remove control characters
  */
-function normalizeText(text: string): string {
+function cleanText(text: string): string {
   if (!text) {
     return '';
   }

--- a/src/embeddings/input.ts
+++ b/src/embeddings/input.ts
@@ -55,7 +55,7 @@ export function selectInput(
  */
 function selectTextContent(data: Partial<ScrapedData>): string | undefined {
   if (data.textContent) {
-      return cleanText(data.textContent);
+    return cleanText(data.textContent);
   }
 
   // Fallback chain: content (markdown) -> excerpt -> description

--- a/src/embeddings/pipeline.ts
+++ b/src/embeddings/pipeline.ts
@@ -58,7 +58,7 @@ export async function generateEmbeddings(
     const model = getEffectiveModel(options.provider, options.model);
 
     // Step 2: Select input text
-    const rawInput = selectInput(data, options.input);
+    const rawInput = selectInput(data, options.input, options.preferNormalized);
     const validation = validateInput(rawInput, options.safety?.minTextLength ?? 10);
 
     if (!validation.valid) {

--- a/src/embeddings/types.ts
+++ b/src/embeddings/types.ts
@@ -312,6 +312,8 @@ export interface EmbeddingOptions {
   provider: EmbeddingProviderConfig;
   /** Model identifier (overrides provider default) */
   model?: string;
+  /** Prefer normalizedText when available (default: true) */
+  preferNormalized?: boolean;
   /** Input text configuration */
   input?: EmbeddingInputConfig;
   /** Chunking and tokenization settings */

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,24 @@
  * extensible pipeline, and pluggable parsers.
  */
 
+export type {
+  BlockType,
+  ClassifierContext,
+  ClassifierResult,
+  ContentBlock,
+  ContentBlockClassifier,
+  NormalizationMeta,
+  NormalizeOptions,
+  NormalizeResult,
+  TruncateStrategy,
+} from './content/index.js';
+// Content normalization
+export {
+  combineClassifiers,
+  defaultBlockClassifier,
+  normalizeText,
+  parseBlocks,
+} from './content/index.js';
 // Core types and utilities
 export type {
   CompletionOptions,
@@ -31,24 +49,6 @@ export {
   scrape,
   scrapeHtml,
 } from './core/index.js';
-// Content normalization
-export {
-  combineClassifiers,
-  defaultBlockClassifier,
-  parseBlocks,
-  normalizeText,
-} from './content/index.js';
-export type {
-  BlockType,
-  ClassifierContext,
-  ClassifierResult,
-  ContentBlock,
-  ContentBlockClassifier,
-  NormalizeOptions,
-  NormalizeResult,
-  NormalizationMeta,
-  TruncateStrategy,
-} from './content/index.js';
 export type {
   ChunkingConfig,
   // Cache

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,24 @@ export {
   scrape,
   scrapeHtml,
 } from './core/index.js';
+// Content normalization
+export {
+  combineClassifiers,
+  defaultBlockClassifier,
+  parseBlocks,
+  normalizeText,
+} from './content/index.js';
+export type {
+  BlockType,
+  ClassifierContext,
+  ClassifierResult,
+  ContentBlock,
+  ContentBlockClassifier,
+  NormalizeOptions,
+  NormalizeResult,
+  NormalizationMeta,
+  TruncateStrategy,
+} from './content/index.js';
 export type {
   ChunkingConfig,
   // Cache

--- a/test/content/blocks.test.ts
+++ b/test/content/blocks.test.ts
@@ -1,0 +1,71 @@
+import { load } from 'cheerio';
+import { describe, expect, it } from 'vitest';
+import { parseBlocks } from '@/content/blocks.js';
+
+describe('parseBlocks', () => {
+  it('parses headings and paragraphs with levels', () => {
+    const html = `
+      <main>
+        <h1>Main Title</h1>
+        <p>First paragraph.</p>
+        <h2>Section</h2>
+        <p>Second paragraph.</p>
+      </main>
+    `;
+    const $ = load(html);
+    const blocks = parseBlocks($);
+
+    expect(blocks).toHaveLength(4);
+    expect(blocks[0]).toMatchObject({ type: 'heading', level: 1, text: 'Main Title' });
+    expect(blocks[1]).toMatchObject({ type: 'paragraph', text: 'First paragraph.' });
+    expect(blocks[2]).toMatchObject({ type: 'heading', level: 2, text: 'Section' });
+    expect(blocks[3]).toMatchObject({ type: 'paragraph', text: 'Second paragraph.' });
+  });
+
+  it('respects drop selectors and removes noisy elements', () => {
+    const html = `
+      <body>
+        <div class="ad">Sponsored block</div>
+        <p>Keep this.</p>
+        <script>console.log('drop');</script>
+      </body>
+    `;
+    const $ = load(html);
+    const blocks = parseBlocks($, { dropSelectors: ['.ad'] });
+
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({ type: 'paragraph', text: 'Keep this.' });
+  });
+
+  it('caps blocks at maxBlocks', () => {
+    const html = `
+      <body>
+        <p>One</p>
+        <p>Two</p>
+        <p>Three</p>
+      </body>
+    `;
+    const $ = load(html);
+    const blocks = parseBlocks($, { maxBlocks: 2 });
+
+    expect(blocks).toHaveLength(2);
+  });
+
+  it('extracts table text content', () => {
+    const html = `
+      <body>
+        <table>
+          <tr><th>Column A</th><th>Column B</th></tr>
+          <tr><td>Value 1</td><td>Value 2</td></tr>
+        </table>
+      </body>
+    `;
+    const $ = load(html);
+    const blocks = parseBlocks($);
+
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({ type: 'table' });
+    expect(blocks[0]?.text).toContain('Column A');
+    expect(blocks[0]?.text).toContain('Value 1');
+  });
+});

--- a/test/content/classifier.test.ts
+++ b/test/content/classifier.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { defaultBlockClassifier } from '@/content/classifier.js';
+import type { ContentBlock } from '@/content/types.js';
+
+describe('defaultBlockClassifier', () => {
+  it('rejects navigation and footer blocks', () => {
+    const navBlock: ContentBlock = { type: 'nav', text: 'Main menu' };
+    const footerBlock: ContentBlock = { type: 'footer', text: 'All rights reserved' };
+
+    expect(defaultBlockClassifier(navBlock, { index: 0, totalBlocks: 2 }).accept).toBe(false);
+    expect(defaultBlockClassifier(footerBlock, { index: 1, totalBlocks: 2 }).accept).toBe(false);
+  });
+
+  it('rejects boilerplate phrases', () => {
+    const block: ContentBlock = { type: 'paragraph', text: 'Subscribe to our newsletter today' };
+    const result = defaultBlockClassifier(block, { index: 0, totalBlocks: 1 });
+
+    expect(result.accept).toBe(false);
+    expect(result.label).toBe('boilerplate');
+  });
+
+  it('accepts substantive paragraph content', () => {
+    const block: ContentBlock = {
+      type: 'paragraph',
+      text: 'This is a longer paragraph with enough information to be meaningful.',
+    };
+    const result = defaultBlockClassifier(block, { index: 0, totalBlocks: 1 });
+
+    expect(result.accept).toBe(true);
+    expect(result.score).toBeGreaterThan(0.5);
+  });
+});

--- a/test/content/classifier.test.ts
+++ b/test/content/classifier.test.ts
@@ -29,4 +29,52 @@ describe('defaultBlockClassifier', () => {
     expect(result.accept).toBe(true);
     expect(result.score).toBeGreaterThan(0.5);
   });
+
+  it('rejects very short fragments without punctuation', () => {
+    const block: ContentBlock = { type: 'paragraph', text: 'Click here' };
+    const result = defaultBlockClassifier(block, { index: 0, totalBlocks: 1 });
+
+    expect(result.accept).toBe(false);
+    expect(result.label).toBe('too-short');
+  });
+
+  it('accepts short sentences with punctuation', () => {
+    const block: ContentBlock = { type: 'paragraph', text: 'All set.' };
+    const result = defaultBlockClassifier(block, { index: 0, totalBlocks: 1 });
+
+    expect(result.accept).toBe(true);
+  });
+
+  it('rejects media credits and captions', () => {
+    const block: ContentBlock = { type: 'paragraph', text: 'Photo by Jane Doe' };
+    const result = defaultBlockClassifier(block, { index: 0, totalBlocks: 1 });
+
+    expect(result.accept).toBe(false);
+    expect(result.label).toBe('media-credit');
+  });
+
+  it('assigns higher scores to headings by level', () => {
+    const h1: ContentBlock = { type: 'heading', text: 'Title', level: 1 };
+    const h2: ContentBlock = { type: 'heading', text: 'Section', level: 2 };
+    const h3: ContentBlock = { type: 'heading', text: 'Subsection', level: 3 };
+
+    const h1Result = defaultBlockClassifier(h1, { index: 0, totalBlocks: 3 });
+    const h2Result = defaultBlockClassifier(h2, { index: 1, totalBlocks: 3 });
+    const h3Result = defaultBlockClassifier(h3, { index: 2, totalBlocks: 3 });
+
+    expect(h1Result.score).toBe(0.9);
+    expect(h2Result.score).toBe(0.8);
+    expect(h3Result.score).toBe(0.7);
+  });
+
+  it('uses a consistent score for quote and code blocks', () => {
+    const quote: ContentBlock = { type: 'quote', text: 'A concise quote.' };
+    const code: ContentBlock = { type: 'code', text: 'const x = 1;' };
+
+    const quoteResult = defaultBlockClassifier(quote, { index: 0, totalBlocks: 2 });
+    const codeResult = defaultBlockClassifier(code, { index: 1, totalBlocks: 2 });
+
+    expect(quoteResult.score).toBe(0.7);
+    expect(codeResult.score).toBe(0.7);
+  });
 });

--- a/test/content/normalizer.test.ts
+++ b/test/content/normalizer.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeText } from '@/content/normalizer.js';
+import type { ContentBlock } from '@/content/types.js';
+
+describe('normalizeText', () => {
+  it('decodes entities, normalizes whitespace, and strips markdown links', async () => {
+    const blocks: ContentBlock[] = [
+      {
+        type: 'paragraph',
+        text: 'Hello&nbsp;world &amp; [Link](https://example.com)',
+      },
+    ];
+
+    const result = await normalizeText(blocks);
+    expect(result.text).toBe('Hello world & Link');
+  });
+
+  it('truncates at sentence boundaries', async () => {
+    const blocks: ContentBlock[] = [
+      {
+        type: 'paragraph',
+        // Use longer text so sentence boundary falls past 50% of maxChars
+        text: 'This is the first sentence. Second sentence is much longer than the first. Third sentence here.',
+      },
+    ];
+
+    const result = await normalizeText(blocks, { maxChars: 50, truncate: 'sentence' });
+    expect(result.text.endsWith('.')).toBe(true);
+    expect(result.meta.truncated).toBe(true);
+  });
+
+  it('returns empty text when below minChars', async () => {
+    const blocks: ContentBlock[] = [{ type: 'paragraph', text: 'Short' }];
+    const result = await normalizeText(blocks, { minChars: 10 });
+
+    expect(result.text).toBe('');
+    expect(result.meta.blocksAccepted).toBe(0);
+  });
+});

--- a/test/content/normalizer.test.ts
+++ b/test/content/normalizer.test.ts
@@ -25,7 +25,7 @@ describe('normalizeText', () => {
     ];
 
     const result = await normalizeText(blocks, { maxChars: 50, truncate: 'sentence' });
-    expect(result.text.endsWith('.')).toBe(true);
+    expect(result.text).toBe('This is the first sentence.');
     expect(result.meta.truncated).toBe(true);
   });
 

--- a/test/core/scrape-normalize.test.ts
+++ b/test/core/scrape-normalize.test.ts
@@ -28,6 +28,12 @@ describe('scrapeHtml normalization', () => {
     expect(result.normalizedText).toContain('This is the first paragraph.');
     expect(result.normalizedText).not.toContain('Subscribe');
     expect(result.normalizationMeta).toBeDefined();
+    expect(result.normalizationMeta?.blocksTotal).toBeGreaterThan(0);
+    expect(result.normalizationMeta?.blocksAccepted).toBeLessThanOrEqual(
+      result.normalizationMeta?.blocksTotal ?? 0
+    );
+    expect(result.normalizationMeta?.boilerplateRemoved).toBe(true);
     expect(result.normalizedBlocks).toBeDefined();
+    expect(result.normalizedBlocks?.length).toBeGreaterThan(0);
   });
 });

--- a/test/core/scrape-normalize.test.ts
+++ b/test/core/scrape-normalize.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { scrapeHtml } from '@/core/scrape.js';
+
+describe('scrapeHtml normalization', () => {
+  it('produces normalized text and metadata', async () => {
+    const html = `
+      <html>
+        <body>
+          <nav>Home About Subscribe</nav>
+          <main>
+            <h1>Test Article</h1>
+            <p>This is the first paragraph.</p>
+            <p>This is the second paragraph.</p>
+          </main>
+          <footer>All rights reserved</footer>
+        </body>
+      </html>
+    `;
+
+    const result = await scrapeHtml(html, 'https://example.com/article', {
+      normalize: {
+        debug: true,
+        removeBoilerplate: true,
+      },
+    });
+
+    expect(result.normalizedText).toContain('Test Article');
+    expect(result.normalizedText).toContain('This is the first paragraph.');
+    expect(result.normalizedText).not.toContain('Subscribe');
+    expect(result.normalizationMeta).toBeDefined();
+    expect(result.normalizedBlocks).toBeDefined();
+  });
+});

--- a/test/e2e/core-scraping.test.ts
+++ b/test/e2e/core-scraping.test.ts
@@ -148,6 +148,19 @@ describe('Core Scraping (from docs & real-world)', () => {
       expect(result.textContent).not.toContain('document.write');
     });
 
+    it('produces normalized text when enabled', async () => {
+      const result = await scrapeHtml(messyBlogPost, 'https://example.com/blog/messy', {
+        normalize: {
+          mode: 'full',
+          removeBoilerplate: true,
+        },
+      });
+
+      expect(result.normalizedText).toContain('This is the primary content of the article');
+      expect(result.normalizedText).not.toContain('Related Posts');
+      expect(result.normalizationMeta?.blocksAccepted).toBeGreaterThan(0);
+    });
+
     it('resolves relative links in the main content', async () => {
       const result = await scrapeHtml(messyBlogPost, 'https://example.com/blog/messy');
 

--- a/test/embeddings/input.test.ts
+++ b/test/embeddings/input.test.ts
@@ -76,6 +76,24 @@ describe('Input Selection', () => {
       const input = selectInput(dataWithBadWhitespace);
       expect(input).toBe('Hello world.\n\nNew paragraph.');
     });
+
+    it('should prefer normalizedText when available', () => {
+      const dataWithNormalized = {
+        normalizedText: 'Normalized content wins.',
+        textContent: 'Original text content.',
+      };
+      const input = selectInput(dataWithNormalized);
+      expect(input).toBe('Normalized content wins.');
+    });
+
+    it('should ignore normalizedText when preferNormalized is false', () => {
+      const dataWithNormalized = {
+        normalizedText: 'Normalized content wins.',
+        textContent: 'Original text content.',
+      };
+      const input = selectInput(dataWithNormalized, { type: 'textContent' }, false);
+      expect(input).toBe('Original text content.');
+    });
   });
 
   describe('validateInput', () => {


### PR DESCRIPTION
- Add block parsing, classification, and normalization utilities
- Integrate normalize option into scraping flow before LLM
- Export normalizedText/meta/blocks; embeddings prefer normalizedText
- Add ReDoS guard, maxBlocks limit, and opt-in HTML capture

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional normalize workflow: returns normalizedText, normalizationMeta and (debug) normalizedBlocks; embeddings prefer normalized text by default.

* **Utilities**
  * Public parsing, normalization, and combinable classifier utilities for custom workflows and classifiers.

* **Security**
  * Hardening: ReDoS protections, maxBlocks limits, safer includeHtml handling, and content hashing for deduplication.

* **Documentation**
  * Updated docs, examples (normalization demo), install notes and changelog.

* **Tests**
  * New unit, integration, and e2e tests covering parsing, classification, normalization, and embedding input selection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->