### PR TITLE
feat(rss,normalization): add feed item normalization and namespaced a…

### DIFF
--- a/.github/releases/v1.0.0-beta.5.md
+++ b/.github/releases/v1.0.0-beta.5.md
@@ -1,0 +1,82 @@
+# scrapex v1.0.0-beta.5
+
+Feed item normalization and enhanced Media RSS support for podcast and media-rich feeds.
+
+## Highlights
+
+- New `normalizeFeedItem()` helper to convert RSS/Atom item content into clean, embedding-ready text
+- Support for `selector@attr` syntax in customFields to extract XML attribute values (e.g., `media:thumbnail@url`)
+- Enhanced Media RSS namespace handling for podcast and media feeds
+
+## New Features
+
+### Feed Item Normalization
+
+```ts
+import { RSSParser, normalizeFeedItem } from 'scrapex';
+
+const parser = new RSSParser();
+const feed = parser.parse(xml, 'https://example.com/feed.xml');
+
+for (const item of feed.data.items) {
+  const normalized = await normalizeFeedItem(item, {
+    mode: 'full',
+    removeBoilerplate: true,
+  });
+
+  console.log(normalized.text);       // Clean text from item.content or item.description
+  console.log(normalized.meta);       // charCount, tokenEstimate, hash, etc.
+}
+```
+
+### Attribute Extraction with selector@attr
+
+Extract XML attribute values from namespaced elements:
+
+```ts
+const parser = new RSSParser({
+  customFields: {
+    // Extract url attribute from media:thumbnail element
+    thumbnail: 'media\\:thumbnail@url',
+    // Extract url attribute from media:content element
+    contentUrl: 'media\\:content@url',
+  },
+});
+
+const result = parser.parse(mediaRssFeed);
+console.log(result.data.items[0]?.customFields?.thumbnail);
+// => "https://example.com/images/thumbnail.jpg"
+```
+
+## Improvements
+
+- `normalizeFeedItem()` falls back to plain text extraction when HTML parsing yields no blocks
+- Improved handling of `content:encoded` CDATA sections
+- Better attribute validation in `selector@attr` parsing
+
+## Test Coverage
+
+- New `rss2-media.xml` fixture covering Media RSS namespace scenarios
+- E2e tests for `normalizeFeedItem()` with various content types
+- E2e tests for `selector@attr` custom field extraction
+
+## Documentation
+
+- Updated RSS parsing guide with normalization examples
+- Updated API docs for `RSSParser` and `normalizeFeedItem()`
+- New example in `examples/20-rss-parsing.ts`
+
+## Installation
+
+```bash
+npm install scrapex@beta
+```
+
+## Notes
+
+- Requires **Node.js 20+**.
+- `normalizeFeedItem()` uses the same normalization pipeline as `scrape({ normalize: ... })`
+
+---
+
+**Full Changelog**: [v1.0.0-beta.4...v1.0.0-beta.5](https://github.com/developer-rakeshpaul/scrapex/compare/v1.0.0-beta.4...v1.0.0-beta.5)

--- a/docs/src/content/docs/api/parsers.mdx
+++ b/docs/src/content/docs/api/parsers.mdx
@@ -17,8 +17,24 @@ class RSSParser {
 }
 
 interface RSSParserOptions {
+  /** Use `selector@attr` for attribute values (e.g. `media\\:thumbnail@url`). */
   customFields?: Record<string, string>;
 }
+```
+
+### normalizeFeedItem
+
+Normalize a `FeedItem` into clean, embedding-ready text.
+
+```typescript
+import { normalizeFeedItem } from 'scrapex';
+
+const normalized = await normalizeFeedItem(item, {
+  mode: 'full',
+  removeBoilerplate: true,
+});
+
+console.log(normalized.text);
 ```
 
 ### ParsedFeed

--- a/docs/src/content/docs/guides/rss-parsing.mdx
+++ b/docs/src/content/docs/guides/rss-parsing.mdx
@@ -136,6 +136,28 @@ const text = feedToText(result.data, { maxItems: 5 });
   Use `feedToMarkdown()` when structure matters (headings, links, feed title). Use `feedToText()` for lower token counts (items only, no feed title).
 </Aside>
 
+## Normalize Feed Items
+
+Normalize item HTML into clean, embedding-ready text:
+
+```typescript
+import { RSSParser, normalizeFeedItem } from 'scrapex';
+
+const parser = new RSSParser();
+const result = parser.parse(feedXml, 'https://example.com/feed.xml');
+
+const item = result.data.items[0];
+if (item) {
+  const normalized = await normalizeFeedItem(item, {
+    mode: 'full',
+    removeBoilerplate: true,
+  });
+
+  console.log(normalized.text);
+  console.log(normalized.meta);
+}
+```
+
 ## Pagination
 
 Some Atom feeds support pagination via `rel="next"` links (RFC 5005):
@@ -161,6 +183,7 @@ const parser = new RSSParser({
   customFields: {
     duration: 'itunes\\:duration',
     explicit: 'itunes\\:explicit',
+    thumbnailUrl: 'media\\:thumbnail@url',
     episode: 'itunes\\:episode',
     season: 'itunes\\:season',
   },
@@ -176,7 +199,8 @@ for (const episode of result.data.items) {
 ```
 
 <Aside type="note">
-  Note the escaped colons (`\\:`) in namespace selectors. This is required for Cheerio's CSS selector syntax.
+  Note the escaped colons (`\\:`) in namespace selectors. This is required for Cheerio's CSS selector syntax
+  when targeting namespaced elements.
 </Aside>
 
 ## Enclosures (Media)

--- a/examples/20-rss-parsing.ts
+++ b/examples/20-rss-parsing.ts
@@ -7,11 +7,12 @@
  */
 
 import {
-  RSSParser,
   discoverFeeds,
   feedToMarkdown,
   fetchFeed,
   filterByDate,
+  normalizeFeedItem,
+  RSSParser,
 } from '../src/index.js';
 
 const SAMPLE_RSS = `<?xml version="1.0" encoding="UTF-8"?>
@@ -59,6 +60,15 @@ async function main() {
     publishedAt: parsed.data.items[0]?.publishedAt,
     enclosure: parsed.data.items[0]?.enclosure?.url,
   });
+
+  if (parsed.data.items[0]) {
+    const normalized = await normalizeFeedItem(parsed.data.items[0], {
+      removeBoilerplate: true,
+      mode: 'full',
+    });
+    console.log('\n--- Normalized First Item ---');
+    console.log(normalized.text);
+  }
 
   console.log('\n--- Markdown Preview ---');
   console.log(feedToMarkdown(parsed.data, { maxItems: 2 }));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrapex",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "description": "Modern web scraper with LLM-enhanced extraction, extensible pipeline, and pluggable parsers",
   "type": "module",
   "exports": {

--- a/src/content/blocks.ts
+++ b/src/content/blocks.ts
@@ -40,7 +40,17 @@ const BLOCK_TYPE_SELECTORS: Record<string, BlockType> = {
 };
 
 /**
- * Parse HTML into content blocks.
+ * Parse HTML into content blocks for normalization.
+ *
+ * Extracts block-level elements (headings, paragraphs, lists, etc.) from HTML,
+ * classifying each by type and preserving structural context.
+ *
+ * @param $ - Cheerio instance with loaded HTML
+ * @param options - Parsing options
+ * @param options.dropSelectors - Additional CSS selectors to remove before parsing
+ * @param options.maxBlocks - Maximum blocks to extract (default: 2000)
+ * @param options.includeHtml - Include raw HTML in block output (default: false)
+ * @returns Array of classified content blocks
  */
 export function parseBlocks(
   $: CheerioAPI,

--- a/src/content/classifier.ts
+++ b/src/content/classifier.ts
@@ -2,7 +2,21 @@ import type { ClassifierResult, ContentBlock, ContentBlockClassifier } from './t
 
 /**
  * Default site-agnostic block classifier.
- * Filters navigation, footers, boilerplate, and short fragments.
+ *
+ * Filters out common boilerplate content including:
+ * - Navigation and footer blocks
+ * - Legal/promotional content
+ * - Boilerplate phrases (subscribe, share, comments, etc.)
+ * - Media credits and captions
+ * - Very short fragments (< 20 chars without punctuation)
+ *
+ * Assigns relevance scores based on block type:
+ * - Headings: 0.7-0.9 (by level)
+ * - Paragraphs: 0.5-0.9 (by length)
+ * - Quotes/Code: 0.7
+ *
+ * @param block - Content block to classify
+ * @returns Classification result with accept/reject decision and score
  */
 export const defaultBlockClassifier: ContentBlockClassifier = (
   block: ContentBlock
@@ -71,8 +85,22 @@ export const defaultBlockClassifier: ContentBlockClassifier = (
 };
 
 /**
- * Create a classifier that combines multiple classifiers.
- * First classifier to reject wins; scores are averaged.
+ * Create a classifier that combines multiple classifiers with AND semantics.
+ *
+ * All classifiers must accept for the block to be accepted.
+ * First classifier to reject wins (early exit).
+ * Scores from all accepting classifiers are averaged.
+ *
+ * @param classifiers - Classifiers to combine
+ * @returns Combined classifier function
+ *
+ * @example
+ * ```ts
+ * const myClassifier = combineClassifiers(
+ *   defaultBlockClassifier,
+ *   (block) => ({ accept: !block.text.includes('ad'), label: 'no-ads' })
+ * );
+ * ```
  */
 export function combineClassifiers(
   ...classifiers: ContentBlockClassifier[]

--- a/src/content/normalizer.ts
+++ b/src/content/normalizer.ts
@@ -10,7 +10,14 @@ import type {
 } from './types.js';
 
 /**
- * Normalize text with optional HTML entity decoding and Unicode normalization.
+ * Normalize a text string with configurable transformations.
+ *
+ * Applies HTML entity decoding, markdown link stripping, Unicode normalization,
+ * whitespace collapsing, and line break handling based on options.
+ *
+ * @param text - Raw text to normalize
+ * @param options - Normalization options
+ * @returns Cleaned and normalized text string
  */
 function normalizeString(
   text: string,
@@ -57,7 +64,17 @@ function normalizeString(
 }
 
 /**
- * Truncate text at natural boundaries.
+ * Truncate text at natural boundaries based on strategy.
+ *
+ * Strategies:
+ * - `sentence`: Truncate at last sentence boundary (. ! ?) if within 50% of maxChars
+ * - `word`: Truncate at last word boundary if within 80% of maxChars
+ * - `char`: Hard truncate at maxChars (no boundary detection)
+ *
+ * @param text - Text to truncate
+ * @param maxChars - Maximum character limit
+ * @param strategy - Truncation strategy
+ * @returns Truncated text and whether truncation occurred
  */
 function truncateText(
   text: string,
@@ -100,7 +117,25 @@ function generateHash(text: string): string {
 }
 
 /**
- * Normalize content blocks into clean text.
+ * Normalize content blocks into clean, embedding-ready text.
+ *
+ * Applies block classification (optional), text normalization, truncation,
+ * and generates metadata including character count, token estimate, and content hash.
+ *
+ * @param blocks - Content blocks to normalize
+ * @param options - Normalization options (mode, maxChars, classifier, etc.)
+ * @param url - Source URL for classifier context
+ * @returns Normalized text, metadata, and optionally classified blocks (when debug: true)
+ *
+ * @example
+ * ```ts
+ * const result = await normalizeText(blocks, {
+ *   mode: 'summary',
+ *   maxChars: 2000,
+ *   removeBoilerplate: true,
+ * });
+ * console.log(result.text, result.meta.tokenEstimate);
+ * ```
  */
 export async function normalizeText(
   blocks: ContentBlock[],

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,7 +118,7 @@ export {
   type RobotsCheckResult,
 } from './fetchers/index.js';
 // Parsers
-export { RSSParser } from './parsers/index.js';
+export { normalizeFeedItem, RSSParser } from './parsers/index.js';
 // Utilities (URL + Feed)
 export {
   discoverFeeds,

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -17,7 +17,7 @@ export {
 } from './markdown.js';
 export type { RSSParserOptions } from './rss.js';
 // RSS parser (pure parsing, no I/O)
-export { RSSParser } from './rss.js';
+export { normalizeFeedItem, RSSParser } from './rss.js';
 
 export type {
   CodeBlock,

--- a/src/parsers/rss.ts
+++ b/src/parsers/rss.ts
@@ -1,5 +1,7 @@
 import * as cheerio from 'cheerio';
 import type { Element } from 'domhandler';
+import { normalizeText, parseBlocks } from '../content/index.js';
+import type { ContentBlock, NormalizeOptions, NormalizeResult } from '../content/types.js';
 import type {
   FeedEnclosure,
   FeedItem,
@@ -13,6 +15,7 @@ export interface RSSParserOptions {
   /**
    * Map of custom field names to CSS selectors or XML tag names.
    * Useful for extracting podcast/media namespace fields.
+   * Use `selector@attr` to extract attribute values (e.g. `media\\:thumbnail@url`).
    * @example { duration: "itunes\:duration", rating: "media\:rating" }
    */
   customFields?: Record<string, string>;
@@ -267,13 +270,41 @@ export class RSSParser implements SourceParser<ParsedFeed, FeedMeta> {
 
     const fields: Record<string, string> = {};
     for (const [key, selector] of Object.entries(this.customFields)) {
-      const value = $el.find(selector).text().trim();
+      const value = this.safeFindText($el, selector);
       if (value) {
         fields[key] = value;
       }
     }
 
     return Object.keys(fields).length > 0 ? fields : undefined;
+  }
+
+  private safeFindText($el: cheerio.Cheerio<Element>, selector: string): string {
+    try {
+      const { tagSelector, attr } = this.parseSelectorAndAttr(selector);
+      const $found = $el.find(tagSelector);
+      if (attr) {
+        return ($found.attr(attr) || '').trim();
+      }
+      return $found.text().trim();
+    } catch (_error) {
+      return '';
+    }
+  }
+
+  private parseSelectorAndAttr(selector: string): { tagSelector: string; attr?: string } {
+    const atIndex = selector.lastIndexOf('@');
+    if (atIndex <= 0 || atIndex === selector.length - 1) {
+      return { tagSelector: selector };
+    }
+
+    const tagSelector = selector.slice(0, atIndex);
+    const attr = selector.slice(atIndex + 1);
+    if (!/^[A-Za-z_][\w:-]*$/.test(attr)) {
+      return { tagSelector: selector };
+    }
+
+    return { tagSelector, attr };
   }
 
   /**
@@ -418,4 +449,35 @@ export class RSSParser implements SourceParser<ParsedFeed, FeedMeta> {
     const num = parseInt(value, 10);
     return Number.isNaN(num) ? undefined : num;
   }
+}
+
+/**
+ * Normalize a feed item into clean, embedding-ready text.
+ * Prefers item.content over item.description.
+ */
+export async function normalizeFeedItem(
+  item: FeedItem,
+  options: NormalizeOptions = {}
+): Promise<NormalizeResult> {
+  const html = item.content || item.description || '';
+  const $ = cheerio.load(html);
+  let blocks: ContentBlock[] = parseBlocks($, {
+    dropSelectors: options.dropSelectors,
+    maxBlocks: options.maxBlocks,
+    includeHtml: options.includeHtml,
+  });
+
+  if (blocks.length === 0) {
+    const fallbackText = $.root().text().trim();
+    if (fallbackText) {
+      blocks = [
+        {
+          type: 'paragraph',
+          text: fallbackText,
+        },
+      ];
+    }
+  }
+
+  return normalizeText(blocks, options, item.link || undefined);
 }

--- a/test/fixtures/rss2-media.xml
+++ b/test/fixtures/rss2-media.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0"
+  xmlns:media="http://search.yahoo.com/mrss/"
+  xmlns:content="http://purl.org/rss/1.0/modules/content/"
+  xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xmlns:atom="http://www.w3.org/2005/Atom">
+<channel>
+  <title>Media RSS Test Feed</title>
+  <link>https://example.com</link>
+  <description>Testing Media RSS namespace parsing with media:thumbnail and media:content</description>
+  <language>en-us</language>
+  <pubDate>Fri, 03 Jan 2026 12:00:00 +0000</pubDate>
+  <lastBuildDate>Fri, 03 Jan 2026 12:00:00 +0000</lastBuildDate>
+
+  <!-- Item with media:thumbnail -->
+  <item>
+    <title>Article with Media Thumbnail</title>
+    <link>https://example.com/article-1</link>
+    <guid>https://example.com/article-1</guid>
+    <pubDate>Fri, 03 Jan 2026 10:00:00 +0000</pubDate>
+    <description>This article has a media:thumbnail element.</description>
+    <media:thumbnail url="https://example.com/images/thumbnail-1.jpg" width="150" height="150" />
+    <dc:creator>John Doe</dc:creator>
+  </item>
+
+  <!-- Item with media:content -->
+  <item>
+    <title>Article with Media Content</title>
+    <link>https://example.com/article-2</link>
+    <guid>https://example.com/article-2</guid>
+    <pubDate>Fri, 03 Jan 2026 09:00:00 +0000</pubDate>
+    <description>This article has a media:content element with an image.</description>
+    <media:content url="https://example.com/images/full-image-2.jpg" type="image/jpeg" width="1200" height="800" />
+    <dc:creator>Jane Smith</dc:creator>
+  </item>
+
+  <!-- Item with both media:thumbnail and media:content -->
+  <item>
+    <title>Article with Both Media Elements</title>
+    <link>https://example.com/article-3</link>
+    <guid>https://example.com/article-3</guid>
+    <pubDate>Fri, 03 Jan 2026 08:00:00 +0000</pubDate>
+    <description>This article has both media:thumbnail and media:content elements.</description>
+    <content:encoded><![CDATA[<p>Full article content with <strong>HTML</strong> formatting.</p>]]></content:encoded>
+    <media:thumbnail url="https://example.com/images/thumb-3.jpg" />
+    <media:content url="https://example.com/images/hero-3.jpg" type="image/jpeg" medium="image">
+      <media:title>Hero Image</media:title>
+      <media:description>The main image for this article</media:description>
+    </media:content>
+    <dc:creator>Bob Wilson</dc:creator>
+  </item>
+
+  <!-- Item with media:group containing multiple media elements -->
+  <item>
+    <title>Article with Media Group</title>
+    <link>https://example.com/article-4</link>
+    <guid>https://example.com/article-4</guid>
+    <pubDate>Fri, 03 Jan 2026 07:00:00 +0000</pubDate>
+    <description>This article uses media:group for multiple media items.</description>
+    <media:group>
+      <media:content url="https://example.com/video/clip.mp4" type="video/mp4" medium="video" />
+      <media:thumbnail url="https://example.com/images/video-thumb.jpg" width="320" height="180" />
+    </media:group>
+  </item>
+
+  <!-- Item with no media elements (standard RSS) -->
+  <item>
+    <title>Standard RSS Item Without Media</title>
+    <link>https://example.com/article-5</link>
+    <guid>https://example.com/article-5</guid>
+    <pubDate>Fri, 03 Jan 2026 06:00:00 +0000</pubDate>
+    <description>This is a standard RSS item without any media namespace elements.</description>
+    <enclosure url="https://example.com/audio/podcast.mp3" length="12345678" type="audio/mpeg" />
+  </item>
+
+</channel>
+</rss>


### PR DESCRIPTION
- Add normalizeFeedItem() helper and export it from parsers/index and root
- Support selector@attr for RSS customFields (e.g., media\:thumbnail@url)
- Add RSS item normalization example and guide/API docs
- Fix normalizeFeedItem fallback for plain-text descriptions
- Add e2e coverage for normalization and Media RSS custom fields

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added normalizeFeedItem to produce embedding-ready text and metadata.
  * Added selector@attr syntax for extracting attributes (with namespace support).
  * Improved Media RSS content extraction and attribute handling.

* **Documentation**
  * Updated API docs and RSS parsing guide with normalization examples and usage notes.

* **Tests**
  * Added Media RSS fixture and E2E/unit tests for normalization and selector@attr extraction.

* **Chores**
  * Bumped package to v1.0.0-beta.5.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->